### PR TITLE
Add BeautifulSoup parsing and convert CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 ## Unreleased
-- Add basic HTML parser and document fetcher.
+- Replace regex-based parser with BeautifulSoup implementation.
+- Add `convert` command to the CLI.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ the structure defined below.
 
 The output can be saved into json or yaml formats.
 
+## Command Line Usage
+
+The package installs a console script named `leropa`. The `convert` command
+retrieves a document by its identifier and prints the structured representation
+as JSON:
+
+```
+leropa convert 123456
+```
+
+The command caches downloaded HTML in the user home directory to speed up
+subsequent conversions.
+
 ## Output Structure
 
 The top level object for each document level version is a dictionary

--- a/leropa/cli.py
+++ b/leropa/cli.py
@@ -1,10 +1,18 @@
+import json
 import logging
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import Optional
 
 import click
 from dotenv import load_dotenv
 
-from leropa.__version__ import __version__
+from leropa import parser
+
+try:
+    __version__ = version("leropa")
+except PackageNotFoundError:
+    __version__ = "0.0.1-dev"
 
 
 @click.group()
@@ -17,6 +25,13 @@ from leropa.__version__ import __version__
 )
 @click.version_option(__version__, prog_name="leropa")
 def cli(debug: bool, trace: bool, log_file: Optional[str] = None) -> None:
+    """Configure logging and load environment variables.
+
+    Args:
+        debug: Toggle debug logging.
+        trace: Toggle trace logging.
+        log_file: Optional path to the log file.
+    """
     if trace:
         level = 1
     elif debug:
@@ -35,3 +50,28 @@ def cli(debug: bool, trace: bool, log_file: Optional[str] = None) -> None:
     if debug:
         logging.debug("Debug mode is on")
     load_dotenv()
+
+
+@cli.command()
+@click.argument("ver_id")
+@click.option(
+    "--cache-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default=None,
+    help="Directory for the HTML cache.",
+)
+def convert(ver_id: str, cache_dir: Optional[str] = None) -> None:
+    """Convert a document identifier to JSON.
+
+    Args:
+        ver_id: Identifier for the document version to convert.
+        cache_dir: Directory used to cache downloaded HTML files.
+    """
+
+    cache_path = Path(cache_dir) if cache_dir else None
+
+    # Retrieve and parse the document structure.
+    doc = parser.fetch_document(ver_id, cache_path)
+
+    # Output the structured representation as JSON.
+    click.echo(json.dumps(doc, ensure_ascii=False))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "click>=8.1.8,<9",
   "dotenv>=0.9.9",
   "requests>=2.32.3,<3",
-
+  "beautifulsoup4>=4.12,<5",
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+"""Tests for the command line interface."""
+
+from click.testing import CliRunner
+from pytest_mock import MockerFixture
+
+from leropa import cli
+
+
+def test_convert_outputs_json(mocker: MockerFixture) -> None:
+    """Ensure converting a document id outputs JSON."""
+
+    sample = {"document": {"ver_id": "123"}, "articles": []}
+    mocker.patch("leropa.parser.fetch_document", return_value=sample)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["convert", "123"])
+
+    assert result.exit_code == 0
+    assert '"ver_id": "123"' in result.output


### PR DESCRIPTION
## Summary
- parse documents with BeautifulSoup instead of regex
- add `convert` command to CLI for converting a document by id
- document CLI usage and depend on beautifulsoup4

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb2dd9af88327a375161a9e8d0e12