### PR TITLE
feat: add file output formats to convert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## Unreleased
 - Replace regex-based parser with BeautifulSoup implementation.
 - Add `convert` command to the CLI.
+- Support writing `convert` output to files.
+- Add YAML and XLSX output formats for `convert` command.

--- a/leropa/cli.py
+++ b/leropa/cli.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from typing import Optional
 
 import click
+import yaml
 from dotenv import load_dotenv
+from openpyxl import Workbook
 
 from leropa import parser
 
@@ -60,12 +62,33 @@ def cli(debug: bool, trace: bool, log_file: Optional[str] = None) -> None:
     default=None,
     help="Directory for the HTML cache.",
 )
-def convert(ver_id: str, cache_dir: Optional[str] = None) -> None:
-    """Convert a document identifier to JSON.
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(file_okay=True, dir_okay=False),
+    default=None,
+    help="Write output to FILE instead of the console.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "yaml", "xlsx"]),
+    default="json",
+    help="Output format.",
+)
+def convert(
+    ver_id: str,
+    cache_dir: Optional[str] = None,
+    output_path: Optional[str] = None,
+    output_format: str = "json",
+) -> None:
+    """Convert a document identifier to structured data.
 
     Args:
         ver_id: Identifier for the document version to convert.
         cache_dir: Directory used to cache downloaded HTML files.
+        output_path: Optional file path for the converted data.
+        output_format: Format of the converted data.
     """
 
     cache_path = Path(cache_dir) if cache_dir else None
@@ -73,5 +96,50 @@ def convert(ver_id: str, cache_dir: Optional[str] = None) -> None:
     # Retrieve and parse the document structure.
     doc = parser.fetch_document(ver_id, cache_path)
 
-    # Output the structured representation as JSON.
-    click.echo(json.dumps(doc, ensure_ascii=False))
+    if output_format == "json":
+        content = json.dumps(doc, ensure_ascii=False)
+        if output_path:
+            Path(output_path).write_text(content, encoding="utf-8")
+        else:
+            click.echo(content)
+    elif output_format == "yaml":
+        content = yaml.safe_dump(doc, allow_unicode=True, sort_keys=False)
+        if output_path:
+            Path(output_path).write_text(content, encoding="utf-8")
+        else:
+            click.echo(content)
+    elif output_format == "xlsx":
+        if output_path is None:
+            raise click.UsageError("Output file is required for xlsx format.")
+
+        workbook = Workbook()
+
+        # Remove default sheet created by Workbook.
+        default_sheet = workbook.active
+        workbook.remove(default_sheet)
+
+        for key, value in doc.items():
+            sheet = workbook.create_sheet(title=key)
+
+            if isinstance(value, list) and value:
+                headers = list(value[0].keys())
+                sheet.append(headers)
+
+                for item in value:
+                    row = []
+                    for h in headers:
+                        cell_value = item.get(h)
+                        if isinstance(cell_value, (list, dict)):
+                            cell_value = json.dumps(
+                                cell_value, ensure_ascii=False
+                            )
+                        row.append(cell_value)
+                    sheet.append(row)
+            elif isinstance(value, dict):
+                sheet.append(list(value.keys()))
+                sheet.append([value.get(k) for k in value.keys()])
+            else:
+                sheet.append(["value"])
+                sheet.append([value])
+
+        workbook.save(output_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
   "dotenv>=0.9.9",
   "requests>=2.32.3,<3",
   "beautifulsoup4>=4.12,<5",
+  "pyyaml>=6.0,<7",
+  "openpyxl>=3.1,<4",
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,11 @@
 """Tests for the command line interface."""
 
+import json
+from pathlib import Path
+
+import yaml
 from click.testing import CliRunner
+from openpyxl import load_workbook
 from pytest_mock import MockerFixture
 
 from leropa import cli
@@ -17,3 +22,66 @@ def test_convert_outputs_json(mocker: MockerFixture) -> None:
 
     assert result.exit_code == 0
     assert '"ver_id": "123"' in result.output
+
+
+def test_convert_writes_json_to_file(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Ensure JSON output is written to a file."""
+
+    sample = {"document": {"ver_id": "123"}, "articles": []}
+    mocker.patch("leropa.parser.fetch_document", return_value=sample)
+
+    out_file = tmp_path / "out.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli, ["convert", "123", "--output", str(out_file)]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(out_file.read_text()) == sample
+
+
+def test_convert_outputs_yaml(mocker: MockerFixture) -> None:
+    """Ensure YAML output is sent to the console."""
+
+    sample = {"document": {"ver_id": "123"}, "articles": []}
+    mocker.patch("leropa.parser.fetch_document", return_value=sample)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["convert", "123", "--format", "yaml"])
+
+    assert result.exit_code == 0
+    assert yaml.safe_load(result.output) == sample
+
+
+def test_convert_writes_xlsx(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Ensure XLSX output writes each data type to its own sheet."""
+
+    sample = {
+        "document": {"ver_id": "123"},
+        "articles": [
+            {"article_id": "a1", "full_text": "abc", "paragraphs": []}
+        ],
+    }
+    mocker.patch("leropa.parser.fetch_document", return_value=sample)
+
+    out_file = tmp_path / "out.xlsx"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "convert",
+            "123",
+            "--format",
+            "xlsx",
+            "--output",
+            str(out_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    workbook = load_workbook(out_file)
+    assert set(workbook.sheetnames) == {"document", "articles"}
+    doc_sheet = workbook["document"]
+    assert doc_sheet.cell(row=2, column=1).value == "123"


### PR DESCRIPTION
## Summary
- allow writing converted documents to a file
- support JSON, YAML and XLSX output formats
- test CLI conversions and XLSX export

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aebae725b08327ae15f7101bfc66bf