### PR TITLE
Parse lettered sub-paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Add `convert` command to the CLI.
 - Support writing `convert` output to files.
 - Add YAML and XLSX output formats for `convert` command.
+- Parse sub-paragraphs labelled with letters within paragraphs.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,9 +7,17 @@ SAMPLE_HTML = """
     <span class="S_ART_TTL" id="id_art1_ttl">Articolul 1</span>
     <span class="S_ART_BDY" id="id_art1_bdy">
         <span class="S_PAR" id="id_par1">First paragraph.</span>
-        <span class="S_ALN" id="id_lit2">
-            <span class="S_ALN_TTL" id="id_lit2_ttl">(1)</span>
-            <span class="S_ALN_BDY" id="id_lit2_bdy">Second paragraph.</span>
+        <span class="S_ALN" id="id_par2">
+            <span class="S_ALN_TTL" id="id_par2_ttl">(1)</span>
+            <span class="S_ALN_BDY" id="id_par2_bdy">Second paragraph.</span>
+        </span>
+        <span class="S_LIT" id="id_lit2a">
+            <span class="S_LIT_TTL" id="id_lit2a_ttl">a)</span>
+            <span class="S_LIT_BDY" id="id_lit2a_bdy">First subparagraph.</span>
+        </span>
+        <span class="S_LIT" id="id_lit2b">
+            <span class="S_LIT_TTL" id="id_lit2b_ttl">b)</span>
+            <span class="S_LIT_BDY" id="id_lit2b_bdy">Second subparagraph.</span>
         </span>
     </span>
 </span>
@@ -24,3 +32,8 @@ def test_parse_html_extracts_articles() -> None:
     assert article["article_id"] == "id_art1"
     assert len(article["paragraphs"]) == 2
     assert article["paragraphs"][0]["text"] == "First paragraph."
+    second_par = article["paragraphs"][1]
+    assert second_par["text"] == "Second paragraph."
+    assert len(second_par["subparagraphs"]) == 2
+    assert second_par["subparagraphs"][0]["label"] == "a)"
+    assert second_par["subparagraphs"][0]["text"] == "First subparagraph."


### PR DESCRIPTION
## Summary
- parse lettered sub-paragraphs within articles
- test parser support for lettered sub-paragraphs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aec62032a08327a90949e6f07bb172