### PR TITLE
Parse letter and paragraph labels

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,11 +13,37 @@ SAMPLE_HTML = """
         </span>
         <span class="S_LIT" id="id_lit2a">
             <span class="S_LIT_TTL" id="id_lit2a_ttl">a)</span>
-            <span class="S_LIT_BDY" id="id_lit2a_bdy">First subparagraph.</span>
+            <span class="S_LIT_BDY" id="id_lit2a_bdy">
+                First subparagraph.
+            </span>
         </span>
         <span class="S_LIT" id="id_lit2b">
             <span class="S_LIT_TTL" id="id_lit2b_ttl">b)</span>
-            <span class="S_LIT_BDY" id="id_lit2b_bdy">Second subparagraph.</span>
+            <span class="S_LIT_BDY" id="id_lit2b_bdy">
+                Second subparagraph.
+            </span>
+        </span>
+    </span>
+</span>
+"""
+
+
+SAMPLE_HTML_BODY_LABEL = """
+<span class="S_ART" id="id_art2">
+    <span class="S_ART_TTL" id="id_art2_ttl">Articolul 2</span>
+    <span class="S_ART_BDY" id="id_art2_bdy">
+        <span class="S_PAR" id="id_par3">Main paragraph.</span>
+        <span class="S_LIT" id="id_lit3a">
+            <span class="S_LIT_TTL" id="id_lit3a_ttl"></span>
+            <span class="S_LIT_BDY" id="id_lit3a_bdy">
+                a) Lettered item.
+            </span>
+        </span>
+        <span class="S_LIT" id="id_lit3b">
+            <span class="S_LIT_TTL" id="id_lit3b_ttl"></span>
+            <span class="S_LIT_BDY" id="id_lit3b_bdy">
+                (1) Numbered item.
+            </span>
         </span>
     </span>
 </span>
@@ -32,8 +58,22 @@ def test_parse_html_extracts_articles() -> None:
     assert article["article_id"] == "id_art1"
     assert len(article["paragraphs"]) == 2
     assert article["paragraphs"][0]["text"] == "First paragraph."
+    assert article["paragraphs"][0]["label"] is None
     second_par = article["paragraphs"][1]
     assert second_par["text"] == "Second paragraph."
+    assert second_par["label"] == "(1)"
     assert len(second_par["subparagraphs"]) == 2
     assert second_par["subparagraphs"][0]["label"] == "a)"
     assert second_par["subparagraphs"][0]["text"] == "First subparagraph."
+
+
+def test_labels_from_body_text() -> None:
+    doc = parser.parse_html(SAMPLE_HTML_BODY_LABEL, "456")
+    article = doc["articles"][0]
+    paragraph = article["paragraphs"][0]
+    sub_a = paragraph["subparagraphs"][0]
+    assert sub_a["label"] == "a)"
+    assert sub_a["text"] == "Lettered item."
+    sub_b = paragraph["subparagraphs"][1]
+    assert sub_b["label"] == "(1)"
+    assert sub_b["text"] == "Numbered item."


### PR DESCRIPTION
## Summary
- capture letter or numbered labels even when embedded in S_LIT_BDY
- store paragraph numeric labels through new `label` field
- add tests for parsing labels from body text

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aec7cc2ff4832796effa79dbae4e04