### PR TITLE
Preserve spacing around inline elements

### DIFF
--- a/leropa/parser.py
+++ b/leropa/parser.py
@@ -262,10 +262,12 @@ def _get_paragraphs(body_tag: Tag) -> tuple[ParagraphList, NoteList]:
                         )
 
                         note.extract()
+
+                # Preserve spaces between inline elements when extracting text.
                 text = (
-                    bdy.get_text(strip=True)
+                    bdy.get_text(" ", strip=True)
                     if bdy
-                    else child.get_text(strip=True)
+                    else child.get_text(" ", strip=True)
                 )
 
                 label_tag = child.find("span", class_="S_ALN_TTL")
@@ -282,7 +284,9 @@ def _get_paragraphs(body_tag: Tag) -> tuple[ParagraphList, NoteList]:
                     )
 
                     note.extract()
-                text = child.get_text(strip=True)
+
+                # Preserve spaces between inline elements when extracting text.
+                text = child.get_text(" ", strip=True)
                 label = None
 
             par_id = child.get("id", "")
@@ -313,8 +317,11 @@ def _get_paragraphs(body_tag: Tag) -> tuple[ParagraphList, NoteList]:
 
                     note.extract()
 
+            # Preserve spaces between inline elements when extracting text.
             text = (
-                bdy.get_text(strip=True) if bdy else child.get_text(strip=True)
+                bdy.get_text(" ", strip=True)
+                if bdy
+                else child.get_text(" ", strip=True)
             )
 
             label = label_tag.get_text(strip=True) if label_tag else ""
@@ -359,7 +366,9 @@ def _get_paragraphs(body_tag: Tag) -> tuple[ParagraphList, NoteList]:
             for note in child.find_all("span", class_="S_PAR"):
                 note.extract()
             par_id = child.get("id", "")
-            text = child.get_text(strip=True)
+
+            # Preserve spaces between inline elements when extracting text.
+            text = child.get_text(" ", strip=True)
             match = re.match(r"^(\([0-9]+\))", text)
             label = match.group(1) if match else None
             if match:
@@ -392,7 +401,9 @@ def _parse_article(art_tag: Tag) -> Article | None:
     paragraphs, notes = _get_paragraphs(body_tag)
 
     # Full text of the article without notes.
-    full_text = body_tag.get_text(strip=True)
+
+    # Preserve spaces between inline elements when extracting text.
+    full_text = body_tag.get_text(" ", strip=True)
 
     return Article(
         article_id=article_id,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -135,6 +135,21 @@ SAMPLE_HTML_WITH_NOTES = """
 """
 
 
+SAMPLE_HTML_WITH_LINK = (
+    '<span class="S_ART" id="id_art_link">'
+    '    <span class="S_ART_TTL" id="id_art_link_ttl">Articolul Link</span>'
+    '    <span class="S_ART_BDY" id="id_art_link_bdy">'
+    '        <span class="S_LIT" id="id_lit_link">'
+    '            <span class="S_LIT_BDY" id="id_lit_link_bdy">(1) '
+    "Este anulabilă căsătoria încheiată fără "
+    "încuviinţările sau autorizarea prevăzute la "
+    "<a href='#'>art. 272</a> alin. (2), (4) şi (5).</span>"
+    "        </span>"
+    "    </span>"
+    "</span>"
+)
+
+
 SAMPLE_HTML_WITH_HISTORY = """
 <html>
   <body>
@@ -237,6 +252,19 @@ def test_parse_notes() -> None:
 
     assert article["notes"][0]["text"] == "Article note."
     assert article["notes"][0]["note_id"] == "id_note_art"
+
+
+def test_preserves_space_around_links() -> None:
+    """Ensure spaces are preserved when parsing inline links."""
+
+    doc = parser.parse_html(SAMPLE_HTML_WITH_LINK, "314")
+    paragraph = doc["articles"][0]["paragraphs"][0]
+    expected = (
+        "Este anulabilă căsătoria încheiată fără încuviinţările "
+        "sau autorizarea prevăzute la art. 272 alin. (2), (4) şi (5)."
+    )
+    assert paragraph["label"] == "(1)"
+    assert paragraph["text"] == expected
 
 
 def test_version_history_extraction() -> None:


### PR DESCRIPTION
## Summary
- ensure parser joins inline elements with spaces to avoid concatenated words
- add regression test for preserving spaces around links

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aed49fc0088327b4e5320c50548c7c