### PR TITLE
Ignore S_LIT_SHORT spans when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Parse consolidation history and expose previous versions.
 - Parse books, titles and chapters linking articles accordingly.
 - Handle numbered paragraphs marked with ``S_LIT`` tags.
+- Ignore hidden ``S_LIT_SHORT`` placeholders to avoid stray ellipsis in text.

--- a/leropa/parser.py
+++ b/leropa/parser.py
@@ -397,6 +397,12 @@ def _parse_article(art_tag: Tag) -> Article | None:
     if body_tag is None:
         return None
 
+    # Remove hidden short placeholders that render as ellipsis.
+    # These spans contain only three dots ("...") and are not meant to be
+    # part of the visible text content.
+    for short in body_tag.find_all("span", class_="S_LIT_SHORT"):
+        short.decompose()
+
     # Extract paragraphs and associated notes.
     paragraphs, notes = _get_paragraphs(body_tag)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,6 +150,24 @@ SAMPLE_HTML_WITH_LINK = (
 )
 
 
+SAMPLE_HTML_WITH_SHORT = """
+<span class="S_ART" id="id_art_short">
+    <span class="S_ART_TTL" id="id_art_short_ttl">Articolul Short</span>
+    <span class="S_ART_BDY" id="id_art_short_bdy">
+        <span class="S_PAR" id="id_par_short">Intro paragraph.</span>
+        <span class="S_LIT" id="id_lit_short">
+            <span class="S_LIT_TTL" id="id_lit_short_ttl">a)</span>
+            <span class="S_LIT_SHORT" id="id_lit_short_short"
+                  style="display: none"> ... </span>
+            <span class="S_LIT_BDY" id="id_lit_short_bdy">
+                Subparagraph text.
+            </span>
+        </span>
+    </span>
+</span>
+"""
+
+
 SAMPLE_HTML_WITH_HISTORY = """
 <html>
   <body>
@@ -265,6 +283,17 @@ def test_preserves_space_around_links() -> None:
     )
     assert paragraph["label"] == "(1)"
     assert paragraph["text"] == expected
+
+
+def test_removes_short_span() -> None:
+    """Ignore hidden short spans that only contain ellipsis."""
+
+    doc = parser.parse_html(SAMPLE_HTML_WITH_SHORT, "515")
+    article = doc["articles"][0]
+    assert article["full_text"] == "Intro paragraph. a) Subparagraph text."
+    paragraph = article["paragraphs"][0]
+    assert paragraph["subparagraphs"][0]["text"] == "Subparagraph text."
+    assert "..." not in article["full_text"]
 
 
 def test_version_history_extraction() -> None:


### PR DESCRIPTION
## Summary
- remove hidden S_LIT_SHORT placeholders from article bodies
- cover S_LIT_SHORT handling with dedicated parser test

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aed6b9bb848327a598c5eca2fe5497