### PR TITLE
Run mypy during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ init-d:
 
 
 test:
+	mypy leropa tests
 	pytest
 
 
@@ -23,4 +24,3 @@ format:
 
 delint: format
 	ruff check --fix .
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,16 @@ leropa = "leropa.__main__:cli"
 dev = [
   "ruff",
   "build",
-  "mypy",
+  "mypy>=1.8,<2",
   "pre-commit",
   "pytest-cov",
   "pytest-mock",
   "pytest",
   "twine",
   "wheel",
+  "types-requests",
+  "types-PyYAML",
+  "types-openpyxl",
 ]
 
 


### PR DESCRIPTION
## Summary
- run mypy as part of `make test`
- pin mypy and include type stub packages in dev dependencies

## Testing
- `make test` *(fails: mypy found typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb3889b08327883209f61edc0be1