### PR TITLE
Exclude venv from ruff fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,6 @@ repos:
       - id: ruff-format
       - id: ruff
         args: [--fix]
+exclude: |-
+  ^venv/
+  ^\.venv/

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ test:
 
 
 lint:
-	ruff check .
+	ruff check --force-exclude .
 
 
 format:
-	ruff format .
+	ruff format --force-exclude .
 
 
 delint: format
-	ruff check --fix .
+	ruff check --fix --force-exclude .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ write_to = "leropa/__version__.py"
 [tool.ruff]
 line-length = 79
 target-version = "py312"
+extend-exclude = ["venv", ".venv"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "ANN"]  # E=pycodestyle, F=pyflakes, I=imports


### PR DESCRIPTION
## Summary
- ensure ruff ignores local virtual environments
- force ruff commands to respect exclude patterns
- keep pre-commit from touching venv directories

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aee6b0aa508327be804dfc41e5d7f3