### PR TITLE
Handle lettered items nested within paragraphs

### DIFF
--- a/leropa/parser/utils.py
+++ b/leropa/parser/utils.py
@@ -119,10 +119,10 @@ def _get_paragraphs(body_tag: Any) -> tuple[ParagraphList, NoteList]:  # noqa: A
             # extract body text and label.
             notes_in_par: NoteList = []
 
-            # Collect line items before extracting paragraph text so that
-            # they don't end up in the paragraph body.
-            line_items = child.find_all("span", class_="S_LIN")
-            for item in line_items:
+            # Collect list items (lettered or dashed) before extracting the
+            # paragraph text so that they don't end up in the paragraph body.
+            list_items = child.find_all("span", class_=["S_LIN", "S_LIT"])
+            for item in list_items:
                 item.extract()
 
             if "S_ALN" in classes:
@@ -161,11 +161,16 @@ def _get_paragraphs(body_tag: Any) -> tuple[ParagraphList, NoteList]:  # noqa: A
             )
             paragraphs.append(current_par)
 
-            # Convert each extracted line item into a subparagraph of the
+            # Convert each extracted list item into a subparagraph of the
             # current paragraph.
-            for item in line_items:
-                label_tag = item.find("span", class_="S_LIN_TTL")
-                bdy = item.find("span", class_="S_LIN_BDY")
+            for item in list_items:
+                item_classes = item.get("class", [])
+                if "S_LIN" in item_classes:
+                    label_tag = item.find("span", class_="S_LIN_TTL")
+                    bdy = item.find("span", class_="S_LIN_BDY")
+                else:
+                    label_tag = item.find("span", class_="S_LIT_TTL")
+                    bdy = item.find("span", class_="S_LIT_BDY")
 
                 # Preserve spaces between inline elements when extracting text.
                 sub_text = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -193,11 +193,37 @@ SAMPLE_HTML_WITH_LINE_ITEMS = """
                 <span class="S_LIN_TTL" id="id_lin2_ttl">– </span>
                 <span class="S_LIN_BDY" id="id_lin2_bdy">Second item;</span>
             </span>
+</span>
+</span>
+</span>
+"""
+
+
+SAMPLE_HTML_LIT_ITEMS_IN_PARAGRAPH = """
+<span class="S_ART" id="id_art_lit_par">
+    <span class="S_ART_TTL" id="id_art_lit_par_ttl">Articolul LitPar</span>
+    <span class="S_ART_BDY" id="id_art_lit_par_bdy">
+        <span class="S_ALN" id="id_par_lit">
+            <span class="S_ALN_TTL" id="id_par_lit_ttl">(1)</span>
+            <span class="S_ALN_BDY" id="id_par_lit_bdy">
+                Intro text:
+                <span class="S_LIT" id="id_lit_a">
+                    <span class="S_LIT_TTL" id="id_lit_a_ttl">a)</span>
+                    <span class="S_LIT_BDY" id="id_lit_a_bdy">
+                        First item;
+                    </span>
+                </span>
+                <span class="S_LIT" id="id_lit_b">
+                    <span class="S_LIT_TTL" id="id_lit_b_ttl">b)</span>
+                    <span class="S_LIT_BDY" id="id_lit_b_bdy">
+                        Second item;
+                    </span>
+                </span>
+            </span>
         </span>
     </span>
 </span>
 """
-
 
 SAMPLE_HTML_WITH_HISTORY = """
 <html>
@@ -358,6 +384,19 @@ def test_line_items_become_subparagraphs() -> None:
     assert len(paragraph["subparagraphs"]) == 2
     first = paragraph["subparagraphs"][0]
     assert first["label"] == "–"
+    assert first["text"] == "First item;"
+
+
+def test_lettered_items_in_paragraph_become_subparagraphs() -> None:
+    """Convert lettered items nested in paragraphs into subparagraphs."""
+
+    doc = parser.parse_html(SAMPLE_HTML_LIT_ITEMS_IN_PARAGRAPH, "717")
+    article = doc["articles"][0]
+    paragraph = article["paragraphs"][0]
+    assert paragraph["text"] == "Intro text:"
+    assert len(paragraph["subparagraphs"]) == 2
+    first = paragraph["subparagraphs"][0]
+    assert first["label"] == "a)"
     assert first["text"] == "First item;"
 
 


### PR DESCRIPTION
## Summary
- treat S_LIT and S_LIN elements inside paragraphs as ordered subparagraphs
- add regression test for lettered items embedded in paragraph bodies

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aee7b745ac8327b1f29e3d48b5e798