### PR TITLE
Include sub-paragraphs in article full text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Handle numbered paragraphs marked with ``S_LIT`` tags.
 - Ignore hidden ``S_LIT_SHORT`` placeholders to avoid stray ellipsis in text.
 - Represent article lists with article identifiers instead of full articles.
+- Include sub-paragraph text in the article ``full_text`` field.

--- a/leropa/parser/utils.py
+++ b/leropa/parser/utils.py
@@ -326,6 +326,31 @@ def _get_paragraphs(body_tag: Any) -> tuple[ParagraphList, NoteList]:  # noqa: A
     return paragraphs, notes
 
 
+def _full_text_from_paragraphs(paragraphs: ParagraphList) -> str:
+    """Combine paragraph and subparagraph text into article text.
+
+    Args:
+        paragraphs: List of paragraphs parsed from the article.
+
+    Returns:
+        String containing the full textual content of the article.
+    """
+
+    parts: list[str] = []
+
+    for par in paragraphs:
+        if par.label:
+            parts.append(par.label)
+
+        parts.append(par.text)
+
+        for sub in par.subparagraphs:
+            label = f"{sub.label} " if sub.label else ""
+            parts.append(f"{label}{sub.text}".strip())
+
+    return _normalize_whitespace(" ".join(parts))
+
+
 def _parse_article(art_tag: Any) -> Article | None:  # noqa: ANN401
     """Create an article dataclass from the given tag.
 
@@ -355,10 +380,7 @@ def _parse_article(art_tag: Any) -> Article | None:  # noqa: ANN401
     # Extract paragraphs and associated notes.
     paragraphs, notes = _get_paragraphs(body_tag)
 
-    # Full text of the article without notes.
-
-    # Preserve spaces between inline elements when extracting text.
-    full_text = _normalize_whitespace(body_tag.get_text(" ", strip=True))
+    full_text = _full_text_from_paragraphs(paragraphs)
 
     return Article(
         article_id=article_id,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -385,6 +385,10 @@ def test_line_items_become_subparagraphs() -> None:
     first = paragraph["subparagraphs"][0]
     assert first["label"] == "–"
     assert first["text"] == "First item;"
+    assert (
+        article["full_text"]
+        == "Termeni utilizați: – First item; – Second item;"
+    )
 
 
 def test_lettered_items_in_paragraph_become_subparagraphs() -> None:


### PR DESCRIPTION
## Summary
- Build article `full_text` from paragraphs so sub-paragraph text is preserved
- Test that line-item subparagraphs appear in article `full_text`
- Document the change in the changelog

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeeac6ac688327aa7d52cbf7990e93