### PR TITLE
Recognize PCT tags as sections

### DIFF
--- a/leropa/parser/utils.py
+++ b/leropa/parser/utils.py
@@ -511,6 +511,11 @@ def _ensure_section(
 
     # Locate the nearest section body containing the article.
     section_body = art_tag.find_parent("span", class_="S_SEC_BDY")
+
+    # Sections can also be marked as points using S_PCT_BDY.
+    if not section_body:
+        section_body = art_tag.find_parent("span", class_="S_PCT_BDY")
+
     if not section_body:
         return None
 
@@ -519,13 +524,20 @@ def _ensure_section(
     section = sections.get(section_id)
 
     if section is None:
-        # Determine the section label and description from preceding siblings.
-        title_tag = section_body.find_previous("span", class_="S_SEC_TTL")
-        desc_tag = section_body.find_previous("span", class_="S_SEC_DEN")
+        # Determine section details based on the section type.
+        if "S_PCT_BDY" in section_body.get("class", []):
+            title_tag = section_body.find_previous("span", class_="S_PCT_TTL")
 
-        # Textual information for the section.
+            # Extract only the direct text, excluding nested article content.
+            desc_text = section_body.find(string=True, recursive=False)
+            description = desc_text.strip() if desc_text else None
+        else:
+            title_tag = section_body.find_previous("span", class_="S_SEC_TTL")
+            desc_tag = section_body.find_previous("span", class_="S_SEC_DEN")
+            description = desc_tag.get_text(strip=True) if desc_tag else None
+
+        # Textual information for the section title.
         sec_title = title_tag.get_text(strip=True) if title_tag else ""
-        description = desc_tag.get_text(strip=True) if desc_tag else None
 
         # Create and store the new section instance.
         section = Section(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -287,6 +287,25 @@ SAMPLE_HTML_SECTION_NO_BOOK = """
 """
 
 
+SAMPLE_HTML_WITH_PCT_SECTION = """
+<span class="S_CAP_TTL" id="id_chap_ttl">Capitolul II</span>
+<span class="S_CAP_BDY" id="id_chap_bdy">
+    <span class="S_PCT" id="id_pct">
+        <span class="S_PCT_TTL" id="id_pct_ttl">2.1.</span>
+        <span class="S_PCT_BDY" id="id_pct_bdy">
+            Cuprinsul cărții funciare
+            <span class="S_ART" id="id_art_pct">
+                <span class="S_ART_TTL" id="id_art_pct_ttl">Articolul 1</span>
+                <span class="S_ART_BDY" id="id_art_pct_bdy">
+                    <span class="S_PAR" id="id_par_pct">Text.</span>
+                </span>
+            </span>
+        </span>
+    </span>
+</span>
+"""
+
+
 def test_parse_html_extracts_articles() -> None:
     doc = parser.parse_html(SAMPLE_HTML, "123")
     assert doc["document"]["ver_id"] == "123"
@@ -485,3 +504,16 @@ def test_section_without_hierarchy() -> None:
     section = chapter["sections"][0]
     assert section["section_id"] == "id_sec_bdy"
     assert section["articles"][0] == "id_artB"
+
+
+def test_pct_section_parsing() -> None:
+    """Parse sections marked with S_PCT_BDY."""
+
+    doc = parser.parse_html(SAMPLE_HTML_WITH_PCT_SECTION, "664")
+    book = doc["books"][0]
+    chapter = book["chapters"][0]
+    section = chapter["sections"][0]
+    assert section["section_id"] == "id_pct_bdy"
+    assert section["title"] == "2.1."
+    assert section["description"] == "Cuprinsul cărții funciare"
+    assert section["articles"][0] == "id_art_pct"


### PR DESCRIPTION
## Summary
- treat `S_PCT_BDY` blocks as sections and extract their titles and descriptions
- add regression test for point-based sections

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeee2f0d2483279949e97152b0559d