### PR TITLE
Structure XLSX export by data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,5 @@
 - Represent article lists with article identifiers instead of full articles.
 - Include sub-paragraph text in the article ``full_text`` field.
 - Generate default hierarchy when chapters or sections lack parent books.
+- Export each data type to its own PascalCase sheet in XLSX output with
+  parent-child identifiers and Excel tables.

--- a/leropa/xlsx.py
+++ b/leropa/xlsx.py
@@ -1,0 +1,315 @@
+"""Utilities for exporting document data to Excel workbooks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from openpyxl import Workbook  # type: ignore[import-untyped]
+from openpyxl.utils import get_column_letter  # type: ignore[import-untyped]
+from openpyxl.worksheet.table import (  # type: ignore[import-untyped]
+    Table,
+    TableStyleInfo,
+)
+
+Sheets = Dict[str, List[Dict[str, Any]]]
+
+
+def _ensure_id(item: Dict[str, Any], prefix: str = "id") -> str:
+    """Return an existing id for ``item`` or generate one.
+
+    Args:
+        item: Mapping representing a data object.
+        prefix: Prefix used when generating a new identifier.
+
+    Returns:
+        The unique identifier for ``item``.
+    """
+
+    for key, value in item.items():
+        if key.endswith("_id") or key == "id":
+            return str(value)
+
+    new_id = f"{prefix}_{uuid4().hex}"
+    item["id"] = new_id
+    return new_id
+
+
+def _flatten(doc: Dict[str, Any]) -> Sheets:
+    """Flatten nested document structure into tabular sheet data.
+
+    Args:
+        doc: Parsed document structure.
+
+    Returns:
+        Mapping of sheet names to row dictionaries.
+    """
+
+    sheets: Sheets = {
+        "Document": [],
+        "HistoryEntry": [],
+        "Book": [],
+        "Title": [],
+        "Chapter": [],
+        "Section": [],
+        "Subsection": [],
+        "Article": [],
+        "Paragraph": [],
+        "SubParagraph": [],
+        "Note": [],
+    }
+
+    # Registry of article data keyed by article identifier.
+    article_lookup: Dict[str, Dict[str, Any]] = {
+        a["article_id"]: a for a in doc.get("articles", [])
+    }
+
+    # Map article identifiers to the parent container identifier.
+    article_parent: Dict[str, str] = {}
+
+    def process_book(book: Dict[str, Any], parent_id: str) -> str:
+        """Process a book structure and its descendants."""
+
+        book_id = _ensure_id(book, "book")
+        book["parent_id"] = parent_id
+
+        # Collect identifiers for nested structures.
+        title_ids: List[str] = []
+        for title in book.get("titles", []):
+            title_ids.append(process_title(title, book_id))
+
+        chapter_ids: List[str] = []
+        for chapter in book.get("chapters", []):
+            chapter_ids.append(process_chapter(chapter, book_id))
+
+        section_ids: List[str] = []
+        for section in book.get("sections", []):
+            section_ids.append(process_section(section, book_id))
+
+        art_ids = book.get("articles", [])
+        for art_id in art_ids:
+            article_parent[art_id] = book_id
+
+        book["titles"] = ",".join(title_ids)
+        book["chapters"] = ",".join(chapter_ids)
+        book["sections"] = ",".join(section_ids)
+        book["articles"] = ",".join(art_ids)
+
+        sheets["Book"].append(book)
+        return book_id
+
+    def process_title(title: Dict[str, Any], parent_id: str) -> str:
+        """Process a title structure and its descendants."""
+
+        title_id = _ensure_id(title, "title")
+        title["parent_id"] = parent_id
+
+        chapter_ids: List[str] = []
+        for chapter in title.get("chapters", []):
+            chapter_ids.append(process_chapter(chapter, title_id))
+
+        section_ids: List[str] = []
+        for section in title.get("sections", []):
+            section_ids.append(process_section(section, title_id))
+
+        art_ids = title.get("articles", [])
+        for art_id in art_ids:
+            article_parent[art_id] = title_id
+
+        title["chapters"] = ",".join(chapter_ids)
+        title["sections"] = ",".join(section_ids)
+        title["articles"] = ",".join(art_ids)
+
+        sheets["Title"].append(title)
+        return title_id
+
+    def process_chapter(chapter: Dict[str, Any], parent_id: str) -> str:
+        """Process a chapter structure and its descendants."""
+
+        chapter_id = _ensure_id(chapter, "chapter")
+        chapter["parent_id"] = parent_id
+
+        section_ids: List[str] = []
+        for section in chapter.get("sections", []):
+            section_ids.append(process_section(section, chapter_id))
+
+        art_ids = chapter.get("articles", [])
+        for art_id in art_ids:
+            article_parent[art_id] = chapter_id
+
+        chapter["sections"] = ",".join(section_ids)
+        chapter["articles"] = ",".join(art_ids)
+
+        sheets["Chapter"].append(chapter)
+        return chapter_id
+
+    def process_section(section: Dict[str, Any], parent_id: str) -> str:
+        """Process a section structure and its descendants."""
+
+        section_id = _ensure_id(section, "section")
+        section["parent_id"] = parent_id
+
+        subsection_ids: List[str] = []
+        for subsection in section.get("subsections", []):
+            subsection_ids.append(process_subsection(subsection, section_id))
+
+        art_ids = section.get("articles", [])
+        for art_id in art_ids:
+            article_parent[art_id] = section_id
+
+        section["subsections"] = ",".join(subsection_ids)
+        section["articles"] = ",".join(art_ids)
+
+        sheets["Section"].append(section)
+        return section_id
+
+    def process_subsection(subsection: Dict[str, Any], parent_id: str) -> str:
+        """Process a subsection structure and its descendants."""
+
+        subsection_id = _ensure_id(subsection, "subsection")
+        subsection["parent_id"] = parent_id
+
+        art_ids = subsection.get("articles", [])
+        for art_id in art_ids:
+            article_parent[art_id] = subsection_id
+
+        subsection["articles"] = ",".join(art_ids)
+
+        sheets["Subsection"].append(subsection)
+        return subsection_id
+
+    def process_paragraph(paragraph: Dict[str, Any], parent_id: str) -> str:
+        """Process a paragraph and its substructures."""
+
+        par_id = _ensure_id(paragraph, "par")
+        paragraph["parent_id"] = parent_id
+
+        sub_ids: List[str] = []
+        for sub in paragraph.get("subparagraphs", []):
+            sub_ids.append(process_subparagraph(sub, par_id))
+
+        note_ids: List[str] = []
+        for note in paragraph.get("notes", []):
+            note_ids.append(process_note(note, par_id))
+
+        paragraph["subparagraphs"] = ",".join(sub_ids)
+        paragraph["notes"] = ",".join(note_ids)
+
+        sheets["Paragraph"].append(paragraph)
+        return par_id
+
+    def process_subparagraph(
+        subparagraph: Dict[str, Any], parent_id: str
+    ) -> str:
+        """Process a sub-paragraph."""
+
+        sub_id = _ensure_id(subparagraph, "sub")
+        subparagraph["parent_id"] = parent_id
+
+        sheets["SubParagraph"].append(subparagraph)
+        return sub_id
+
+    def process_note(note: Dict[str, Any], parent_id: str) -> str:
+        """Process a note attached to an article or paragraph."""
+
+        note_id = _ensure_id(note, "note")
+        note["parent_id"] = parent_id
+
+        sheets["Note"].append(note)
+        return note_id
+
+    # Process the document metadata and history entries.
+    document = doc.get("document", {})
+    doc_id = _ensure_id(document, "doc")
+
+    history_entries = document.pop("history", [])
+    history_ids: List[str] = []
+    for entry in history_entries:
+        entry_id = _ensure_id(entry, "hist")
+        entry["parent_id"] = doc_id
+        sheets["HistoryEntry"].append(entry)
+        history_ids.append(entry_id)
+
+    document["history"] = ",".join(history_ids)
+
+    # Process books and their descendants.
+    book_ids: List[str] = []
+    for book in doc.get("books", []):
+        book_ids.append(process_book(book, doc_id))
+
+    document["books"] = ",".join(book_ids)
+
+    sheets["Document"].append(document)
+
+    # Process all articles, assigning parent references collected earlier.
+    for art_id, article in article_lookup.items():
+        article_id = _ensure_id(article, "article")
+        parent_id = article_parent.get(art_id)
+        if parent_id:
+            article["parent_id"] = parent_id
+
+        paragraph_ids: List[str] = []
+        for paragraph in article.get("paragraphs", []):
+            paragraph_ids.append(process_paragraph(paragraph, article_id))
+
+        note_ids: List[str] = []
+        for note in article.get("notes", []):
+            note_ids.append(process_note(note, article_id))
+
+        article["paragraphs"] = ",".join(paragraph_ids)
+        article["notes"] = ",".join(note_ids)
+
+        sheets["Article"].append(article)
+
+    # Drop entries for which no data was recorded.
+    return {name: rows for name, rows in sheets.items() if rows}
+
+
+def write_workbook(doc: Dict[str, Any], path: Path) -> None:
+    """Write structured data into an Excel workbook.
+
+    Args:
+        doc: Parsed document structure.
+        path: Destination file path for the workbook.
+    """
+
+    data = _flatten(doc)
+
+    # Create a workbook and remove the default sheet created by openpyxl.
+    workbook = Workbook()
+    default_sheet = workbook.active
+    workbook.remove(default_sheet)
+
+    for sheet_name, rows in data.items():
+        ws = workbook.create_sheet(title=sheet_name)
+
+        # Write header row based on dictionary keys.
+        headers = list(rows[0].keys())
+        ws.append(headers)
+
+        for row in rows:
+            values: List[Any] = []
+
+            # Serialize complex structures to JSON strings.
+            for header in headers:
+                cell_value = row.get(header)
+                if isinstance(cell_value, (list, dict)):
+                    cell_value = json.dumps(cell_value, ensure_ascii=False)
+                values.append(cell_value)
+
+            ws.append(values)
+
+        # Determine table range covering the header and all rows.
+        end_column = get_column_letter(len(headers))
+        end_row = len(rows) + 1
+        table = Table(displayName=sheet_name, ref=f"A1:{end_column}{end_row}")
+
+        # Apply a simple table style with row stripes for readability.
+        style = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+        table.tableStyleInfo = style
+
+        ws.add_table(table)
+
+    workbook.save(path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,12 +69,35 @@ def test_convert_outputs_yaml() -> None:
 
 
 def test_convert_writes_xlsx(tmp_path: Path) -> None:
-    """Ensure XLSX output writes each data type to its own sheet."""
+    """Ensure XLSX output organizes data into PascalCase sheets."""
 
     sample = {
         "document": {"ver_id": "123"},
         "articles": [
-            {"article_id": "a1", "full_text": "abc", "paragraphs": []}
+            {
+                "article_id": "a1",
+                "full_text": "abc",
+                "paragraphs": [
+                    {
+                        "par_id": "p1",
+                        "text": "t",
+                        "subparagraphs": [],
+                        "notes": [],
+                    }
+                ],
+                "notes": [],
+            }
+        ],
+        "books": [
+            {
+                "book_id": "b1",
+                "title": "B1",
+                "description": None,
+                "titles": [],
+                "chapters": [],
+                "sections": [],
+                "articles": ["a1"],
+            }
         ],
     }
     out_file = tmp_path / "out.xlsx"
@@ -95,9 +118,17 @@ def test_convert_writes_xlsx(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     workbook = load_workbook(out_file)
-    assert set(workbook.sheetnames) == {"document", "articles"}
-    doc_sheet = workbook["document"]
-    assert doc_sheet.cell(row=2, column=1).value == "123"
+    assert {"Document", "Book", "Article", "Paragraph"} <= set(
+        workbook.sheetnames
+    )
+    book_sheet = workbook["Book"]
+    assert book_sheet.cell(row=2, column=1).value == "b1"
+    article_sheet = workbook["Article"]
+    assert article_sheet.cell(row=2, column=1).value == "a1"
+    # Each sheet contains a table named after the sheet.
+    assert "Book" in book_sheet.tables
+    assert "Article" in article_sheet.tables
+    assert "Paragraph" in workbook["Paragraph"].tables
 
 
 def test_convert_writes_xlsx_to_directory(tmp_path: Path) -> None:
@@ -106,7 +137,12 @@ def test_convert_writes_xlsx_to_directory(tmp_path: Path) -> None:
     sample = {
         "document": {"ver_id": "123"},
         "articles": [
-            {"article_id": "a1", "full_text": "abc", "paragraphs": []}
+            {
+                "article_id": "a1",
+                "full_text": "abc",
+                "paragraphs": [],
+                "notes": [],
+            }
         ],
     }
 
@@ -127,7 +163,7 @@ def test_convert_writes_xlsx_to_directory(tmp_path: Path) -> None:
     out_file = tmp_path / "123.xlsx"
     assert result.exit_code == 0
     workbook = load_workbook(out_file)
-    assert set(workbook.sheetnames) == {"document", "articles"}
+    assert "Document" in workbook.sheetnames
 
 
 def test_convert_writes_xlsx_with_nested_values(tmp_path: Path) -> None:
@@ -158,8 +194,47 @@ def test_convert_writes_xlsx_with_nested_values(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     workbook = load_workbook(out_file)
-    doc_sheet = workbook["document"]
+    doc_sheet = workbook["Document"]
 
     # The versions list is stored as a JSON string in the second column.
     versions_cell = str(doc_sheet.cell(row=2, column=2).value)
     assert json.loads(versions_cell) == sample["document"]["versions"]
+
+
+def test_convert_generates_missing_ids(tmp_path: Path) -> None:
+    """Ensure missing identifiers are generated in the Excel output."""
+
+    sample = {
+        "document": {"ver_id": "123"},
+        "articles": [
+            {
+                "article_id": "a1",
+                "full_text": "abc",
+                "paragraphs": [],
+                "notes": [{"text": "note without id"}],
+            }
+        ],
+    }
+    out_file = tmp_path / "out.xlsx"
+
+    with patch("leropa.parser.fetch_document", return_value=sample):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            [
+                "convert",
+                "123",
+                "--format",
+                "xlsx",
+                "--output",
+                str(out_file),
+            ],
+        )
+
+    assert result.exit_code == 0
+    workbook = load_workbook(out_file)
+    note_sheet = workbook["Note"]
+    headers = [cell.value for cell in note_sheet[1]]
+    id_col = headers.index("id") + 1
+    generated_id = note_sheet.cell(row=2, column=id_col).value
+    assert isinstance(generated_id, str) and generated_id.startswith("note_")


### PR DESCRIPTION
## Summary
- Export documents to XLSX with one PascalCase table per data type
- Link child items to parents via IDs and generate missing identifiers
- Add tests for structured workbook output and ID generation

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aeed3a478883279293ce25e167b659