### PR TITLE
Parse annexes in legal documents

### DIFF
--- a/leropa/parser/annex.py
+++ b/leropa/parser/annex.py
@@ -1,0 +1,24 @@
+"""Data model for document annexes."""
+
+from __future__ import annotations
+
+from attrs import define, field
+
+from .types import NoteList
+
+
+@define(slots=True)
+class Annex:
+    """Represents an annex attached to the legal document.
+
+    Attributes:
+        annex_id: Identifier for the annex element in the source HTML.
+        title: Title of the annex.
+        text: Full textual content of the annex.
+        notes: Notes or changes applied to the annex.
+    """
+
+    annex_id: str
+    title: str
+    text: str
+    notes: NoteList = field(factory=list, repr=False)

--- a/leropa/parser/types.py
+++ b/leropa/parser/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .annex import Annex  # noqa: F401
     from .article import Article  # noqa: F401
     from .book import Book  # noqa: F401
     from .chapter import Chapter  # noqa: F401
@@ -26,3 +27,4 @@ ChapterList = list["Chapter"]
 TitleList = list["Title"]
 BookList = list["Book"]
 SectionList = list["Section"]
+AnnexList = list["Annex"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -199,6 +199,18 @@ SAMPLE_HTML_WITH_LINE_ITEMS = """
 """
 
 
+SAMPLE_HTML_WITH_ANNEX = """
+<span class="S_ANX_TTL" id="id_anx1_ttl">Anexa nr. 1</span>
+<span class="S_ANX_BDY" id="id_anx1_bdy">
+    <span class="S_PAR" id="id_par_annex">Annex content.</span>
+    <span class="S_PAR" id="id_par_annex_note">
+        (la 01-01-2020, Anexa nr. 1 a fost modificată de art. I din LEGEA
+        nr. 1/2020.)
+    </span>
+</span>
+"""
+
+
 SAMPLE_HTML_LIT_ITEMS_IN_PARAGRAPH = """
 <span class="S_ART" id="id_art_lit_par">
     <span class="S_ART_TTL" id="id_art_lit_par_ttl">Articolul LitPar</span>
@@ -471,6 +483,21 @@ def test_line_items_become_subparagraphs() -> None:
     assert (
         article["full_text"]
         == "Termeni utilizați: – First item; – Second item;"
+    )
+
+
+def test_parse_annex() -> None:
+    """Extract annexes along with their notes."""
+
+    doc = parser.parse_html(SAMPLE_HTML_WITH_ANNEX, "700")
+    annexes = doc["annexes"]
+    assert len(annexes) == 1
+    annex = annexes[0]
+    assert annex["annex_id"] == "id_anx1"
+    assert annex["title"] == "Anexa nr. 1"
+    assert annex["text"] == "Annex content."
+    assert annex["notes"][0]["text"].startswith(
+        "(la 01-01-2020, Anexa nr. 1 a fost modificată"
     )
 
 


### PR DESCRIPTION
## Summary
- add Annex dataclass for storing annex metadata and notes
- parse S_ANX sections to extract annex text and amendment notes
- cover annex parsing with unit tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aef7634f008327a6aaba8bb6214a56