### PR TITLE
Parse article labels without 'Articolul' prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,5 @@
   parent-child identifiers and Excel tables.
 - Detect numeric section titles, assigning a ``level`` and nesting child
   sections under their parents.
+- Include article labels parsed from ``S_ART_TTL`` without the ``Articolul``
+  prefix.

--- a/README.md
+++ b/README.md
@@ -159,11 +159,12 @@ Groups articles inside a section:
 
 ### The article
 
-Contains the full text and its components:
+Contains the identifier, label, full text and its components:
 
 ```js
 {
     "article_id": "...",
+    "label": "...",
     "full_text": "...",
     "paragraphs": [...],
     "notes": [...]

--- a/leropa/parser/article.py
+++ b/leropa/parser/article.py
@@ -13,12 +13,14 @@ class Article:
 
     Attributes:
         article_id: Identifier for the article element in the source HTML.
+        label: Article label such as "1".
         full_text: Full text content of the article.
         paragraphs: Ordered collection of paragraphs within the article.
         notes: Notes attached to the article body.
     """
 
     article_id: str
+    label: str
     full_text: str
     paragraphs: ParagraphList = field(factory=list, repr=False)
     notes: NoteList = field(factory=list, repr=False)

--- a/leropa/parser/utils.py
+++ b/leropa/parser/utils.py
@@ -363,6 +363,11 @@ def _parse_article(art_tag: Any) -> Article | None:  # noqa: ANN401
     # Unique identifier of the article.
     article_id = art_tag.get("id", "")
 
+    # Visible label of the article without the "Articolul" prefix.
+    title_tag = art_tag.find("span", class_="S_ART_TTL")
+    label = title_tag.get_text(strip=True) if title_tag else ""
+    label = re.sub(r"^Articolul\s+", "", label)
+
     # Body container that holds the paragraphs and notes.
     body_tag = art_tag.find("span", class_="S_ART_BDY")
     if body_tag is None:
@@ -383,6 +388,7 @@ def _parse_article(art_tag: Any) -> Article | None:  # noqa: ANN401
 
     return Article(
         article_id=article_id,
+        label=label,
         full_text=full_text,
         paragraphs=paragraphs,
         notes=notes,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -144,6 +144,16 @@ SAMPLE_HTML_WITH_NOTES = """
 """
 
 
+SAMPLE_HTML_NO_PREFIX = """
+<span class="S_ART" id="id_art_np">
+    <span class="S_ART_TTL" id="id_art_np_ttl">NoPrefix</span>
+    <span class="S_ART_BDY" id="id_art_np_bdy">
+        <span class="S_PAR" id="id_par_np">Paragraph.</span>
+    </span>
+</span>
+"""
+
+
 SAMPLE_HTML_WITH_LINK = (
     '<span class="S_ART" id="id_art_link">'
     '    <span class="S_ART_TTL" id="id_art_link_ttl">Articolul Link</span>'
@@ -362,6 +372,7 @@ def test_parse_html_extracts_articles() -> None:
     assert len(doc["articles"]) == 1
     article = doc["articles"][0]
     assert article["article_id"] == "id_art1"
+    assert article["label"] == "1"
     assert len(article["paragraphs"]) == 2
     assert article["paragraphs"][0]["text"] == "First paragraph."
     assert article["paragraphs"][0]["label"] is None
@@ -376,6 +387,7 @@ def test_parse_html_extracts_articles() -> None:
 def test_labels_from_body_text() -> None:
     doc = parser.parse_html(SAMPLE_HTML_BODY_LABEL, "456")
     article = doc["articles"][0]
+    assert article["label"] == "2"
     paragraph = article["paragraphs"][0]
     sub_a = paragraph["subparagraphs"][0]
     assert sub_a["label"] == "a)"
@@ -388,6 +400,7 @@ def test_labels_from_body_text() -> None:
 def test_s_lit_paragraphs() -> None:
     doc = parser.parse_html(SAMPLE_HTML_LIT_PARAGRAPHS, "101")
     article = doc["articles"][0]
+    assert article["label"] == "LIT"
     paragraphs = article["paragraphs"]
     assert len(paragraphs) == 2
     first_par = paragraphs[0]
@@ -401,6 +414,12 @@ def test_s_lit_paragraphs() -> None:
     assert second_par["text"] == "Second paragraph."
 
 
+def test_article_label_without_prefix() -> None:
+    doc = parser.parse_html(SAMPLE_HTML_NO_PREFIX, "102")
+    article = doc["articles"][0]
+    assert article["label"] == "NoPrefix"
+
+
 def test_metadata_extraction() -> None:
     doc = parser.parse_html(SAMPLE_HTML_WITH_META, "789")
     info = doc["document"]
@@ -412,6 +431,7 @@ def test_metadata_extraction() -> None:
 def test_parse_notes() -> None:
     doc = parser.parse_html(SAMPLE_HTML_WITH_NOTES, "999")
     article = doc["articles"][0]
+    assert article["label"] == "3"
     paragraph = article["paragraphs"][0]
 
     assert paragraph["text"].strip() == "Paragraph text."


### PR DESCRIPTION
## Summary
- capture article labels and strip the "Articolul" prefix
- expose parsed label on Article and document output
- document and test article labels, keeping titles without prefixes intact

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e246f4f48327bab1d43d5cdb8e13