### PR TITLE
Document CLI and helper parameters

### DIFF
--- a/leropa/llm/export_legal_articles_to_md.py
+++ b/leropa/llm/export_legal_articles_to_md.py
@@ -38,7 +38,15 @@ def now_iso() -> str:
 
 
 def slug(s: str, lim: int = 80) -> str:
-    """Return a slugified version of the string."""
+    """Return a slugified version of the string.
+
+    Args:
+        s: Input string to slugify.
+        lim: Maximum length of the slug.
+
+    Returns:
+        Slugified string.
+    """
 
     # Replace non alphanumeric characters with underscores.
     s = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(s))
@@ -46,14 +54,28 @@ def slug(s: str, lim: int = 80) -> str:
 
 
 def sha1_text(text: str) -> str:
-    """Return the SHA1 hash for the text."""
+    """Return the SHA1 hash for the text.
+
+    Args:
+        text: Input text.
+
+    Returns:
+        Hexadecimal SHA1 digest.
+    """
 
     # Encode text to bytes then compute hash.
     return hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()
 
 
 def _json_loads(data: bytes) -> Dict[str, Any]:
-    """Load JSON bytes using orjson when available."""
+    """Load JSON bytes using orjson when available.
+
+    Args:
+        data: Raw JSON bytes.
+
+    Returns:
+        Parsed JSON object.
+    """
 
     # Use orjson if available, otherwise fall back to json.
     if orjson is not None:
@@ -67,7 +89,14 @@ def _json_loads(data: bytes) -> Dict[str, Any]:
 
 
 def read_any_json(path: str) -> List[Dict[str, Any]]:
-    """Read a JSON or JSONL file and return a list of records."""
+    """Read a JSON or JSONL file and return a list of records.
+
+    Args:
+        path: Path to the JSON or JSONL file.
+
+    Returns:
+        List of record dictionaries.
+    """
 
     out: List[Dict[str, Any]] = []
 
@@ -92,7 +121,14 @@ def read_any_json(path: str) -> List[Dict[str, Any]]:
 
 
 def token_len(text: str) -> int:
-    """Return the token count for the text."""
+    """Return the token count for the text.
+
+    Args:
+        text: Text to count tokens for.
+
+    Returns:
+        Estimated token count.
+    """
 
     if _ENC is None:
         # Quick heuristic: words as tokens.
@@ -143,13 +179,25 @@ def token_chunks(text: str, max_tokens: int, overlap_tokens: int) -> List[str]:
 
 
 def ensure_dir(p: str) -> None:
-    """Create directory if it does not exist."""
+    """Create directory if it does not exist.
+
+    Args:
+        p: Path to the directory.
+    """
 
     os.makedirs(p, exist_ok=True)
 
 
 def normalize_record(rec: Dict[str, Any], source_file: str) -> Dict[str, Any]:
-    """Validate and normalize a record."""
+    """Validate and normalize a record.
+
+    Args:
+        rec: Raw record mapping.
+        source_file: Name of the source file for attribution.
+
+    Returns:
+        Normalized record mapping.
+    """
 
     missing = [k for k in ("full_text", "article_id", "label") if k not in rec]
     if missing:
@@ -179,7 +227,20 @@ def export_folder(
     body_heading: str = "TEXT",
     ext: str = ".md",
 ) -> Tuple[int, int]:
-    """Export all JSON articles inside a folder."""
+    """Export all JSON articles inside a folder.
+
+    Args:
+        input_dir: Directory containing JSON or JSONL files.
+        output_dir: Destination directory for exported files.
+        max_tokens: Maximum tokens per chunk.
+        overlap_tokens: Token overlap between chunks.
+        title_template: Template for document titles.
+        body_heading: Heading shown before article text.
+        ext: Output file extension.
+
+    Returns:
+        Tuple of number of articles processed and files written.
+    """
 
     ensure_dir(output_dir)
 

--- a/leropa/parser/parse_html.py
+++ b/leropa/parser/parse_html.py
@@ -33,7 +33,14 @@ DEFAULT_CHAPTER_ID = "default_chapter"
 
 
 def _get_default_book(books: dict[str, Book]) -> Book:
-    """Return a placeholder book when the source lacks one."""
+    """Return a placeholder book when the source lacks one.
+
+    Args:
+        books: Mapping of existing books keyed by identifier.
+
+    Returns:
+        Placeholder book instance.
+    """
 
     # Retrieve the existing placeholder book if present.
     book = books.get(DEFAULT_BOOK_ID)
@@ -46,7 +53,14 @@ def _get_default_book(books: dict[str, Book]) -> Book:
 
 
 def _get_default_chapter(chapters: dict[str, Chapter]) -> Chapter:
-    """Return a placeholder chapter when the source lacks one."""
+    """Return a placeholder chapter when the source lacks one.
+
+    Args:
+        chapters: Mapping of existing chapters keyed by identifier.
+
+    Returns:
+        Placeholder chapter instance.
+    """
 
     # Retrieve the existing placeholder chapter if present.
     chapter = chapters.get(DEFAULT_CHAPTER_ID)

--- a/leropa/parser/utils.py
+++ b/leropa/parser/utils.py
@@ -17,7 +17,14 @@ from .types import NoteList, ParagraphList
 
 
 def _normalize_whitespace(text: str) -> str:
-    """Collapse consecutive whitespace and tidy punctuation spacing."""
+    """Collapse consecutive whitespace and tidy punctuation spacing.
+
+    Args:
+        text: Raw text to normalize.
+
+    Returns:
+        Text with extraneous whitespace removed.
+    """
 
     cleaned = re.sub(r"\s+", " ", text).strip()
     return re.sub(r"\s+([,.;:!?\)])", r"\1", cleaned)
@@ -83,7 +90,14 @@ def _parse_note_details(text: str) -> dict[str, str | None]:
 
 
 def _note_from_tag(tag: Any) -> Note:  # noqa: ANN401
-    """Create a Note instance from the given HTML tag."""
+    """Create a Note instance from the given HTML tag.
+
+    Args:
+        tag: ``span`` element containing the note.
+
+    Returns:
+        Parsed ``Note`` instance.
+    """
 
     note_id = str(tag.get("id", ""))
     text = _normalize_whitespace(tag.get_text(" ", strip=True))
@@ -291,7 +305,14 @@ def _parse_aln_body(tag: Any) -> Paragraph:  # noqa: ANN401
 
 
 def _get_paragraphs(body_tag: Any) -> tuple[ParagraphList, NoteList]:  # noqa: ANN401
-    """Extract paragraph and note information from an article body tag."""
+    """Extract paragraph and note information from an article body tag.
+
+    Args:
+        body_tag: ``span`` element containing the article body.
+
+    Returns:
+        Tuple of parsed paragraphs and notes.
+    """
 
     paragraphs: ParagraphList = []
     notes: NoteList = []
@@ -396,7 +417,15 @@ def _parse_article(art_tag: Any) -> Article | None:  # noqa: ANN401
 
 
 def _ensure_book(art_tag: Any, books: dict[str, Book]) -> Book | None:  # noqa: ANN401
-    """Retrieve or create a book for the given article tag."""
+    """Retrieve or create a book for the given article tag.
+
+    Args:
+        art_tag: Tag representing the article in the HTML.
+        books: Mapping of existing books keyed by identifier.
+
+    Returns:
+        Existing or newly created ``Book`` instance, or ``None`` when not found.
+    """
 
     # Locate the nearest book body containing the article.
     book_body = art_tag.find_parent("span", class_="S_CRT_BDY")
@@ -427,7 +456,16 @@ def _ensure_title(
     titles: dict[str, Title],
     book: Book | None,
 ) -> Title | None:
-    """Retrieve or create a title for the given article tag."""
+    """Retrieve or create a title for the given article tag.
+
+    Args:
+        art_tag: Tag representing the article in the HTML.
+        titles: Mapping of existing titles keyed by identifier.
+        book: Parent book instance if available.
+
+    Returns:
+        Existing or newly created ``Title`` instance, or ``None`` when not found.
+    """
 
     # Locate the nearest title body containing the article.
     title_body = art_tag.find_parent("span", class_="S_TTL_BDY")
@@ -468,7 +506,17 @@ def _ensure_chapter(
     title: Title | None,
     book: Book | None,
 ) -> Chapter | None:
-    """Retrieve or create a chapter for the given article tag."""
+    """Retrieve or create a chapter for the given article tag.
+
+    Args:
+        art_tag: Tag representing the article in the HTML.
+        chapters: Mapping of existing chapters keyed by identifier.
+        title: Parent title instance if available.
+        book: Parent book instance if available.
+
+    Returns:
+        Existing or newly created ``Chapter`` instance, or ``None`` when not found.
+    """
 
     # Locate the nearest chapter body containing the article.
     chapter_body = art_tag.find_parent("span", class_="S_CAP_BDY")
@@ -513,7 +561,19 @@ def _ensure_section(
     title: Title | None,
     book: Book | None,
 ) -> Section | None:
-    """Retrieve or create a section for the given article tag."""
+    """Retrieve or create a section for the given article tag.
+
+    Args:
+        art_tag: Tag representing the article in the HTML.
+        sections: Mapping of existing sections keyed by identifier.
+        section_titles: Mapping of section numbers to section objects.
+        chapter: Parent chapter instance if available.
+        title: Parent title instance if available.
+        book: Parent book instance if available.
+
+    Returns:
+        Existing or newly created ``Section`` instance, or ``None`` when not found.
+    """
 
     # Locate the nearest section body containing the article.
     section_body = art_tag.find_parent("span", class_="S_SEC_BDY")
@@ -595,7 +655,17 @@ def _ensure_subsection(
     section_titles: dict[str, Section],
     section: Section | None,
 ) -> Section | None:
-    """Retrieve or create a subsection for the given article tag."""
+    """Retrieve or create a subsection for the given article tag.
+
+    Args:
+        art_tag: Tag representing the article in the HTML.
+        sections: Mapping of existing sections keyed by identifier.
+        section_titles: Mapping of section numbers to section objects.
+        section: Parent section instance if available.
+
+    Returns:
+        Existing or newly created subsection instance, or ``None`` when not found.
+    """
 
     if not section:
         return None

--- a/leropa/xlsx.py
+++ b/leropa/xlsx.py
@@ -74,7 +74,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
     article_parent: Dict[str, str] = {}
 
     def process_book(book: Dict[str, Any], parent_id: str) -> str:
-        """Process a book structure and its descendants."""
+        """Process a book structure and its descendants.
+
+        Args:
+            book: Mapping describing the book structure.
+            parent_id: Identifier of the parent container.
+
+        Returns:
+            Generated identifier for the book.
+        """
 
         book_id = _ensure_id(book, "book")
         book["parent_id"] = parent_id
@@ -105,7 +113,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
         return book_id
 
     def process_title(title: Dict[str, Any], parent_id: str) -> str:
-        """Process a title structure and its descendants."""
+        """Process a title structure and its descendants.
+
+        Args:
+            title: Mapping describing the title structure.
+            parent_id: Identifier of the parent container.
+
+        Returns:
+            Generated identifier for the title.
+        """
 
         title_id = _ensure_id(title, "title")
         title["parent_id"] = parent_id
@@ -130,7 +146,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
         return title_id
 
     def process_chapter(chapter: Dict[str, Any], parent_id: str) -> str:
-        """Process a chapter structure and its descendants."""
+        """Process a chapter structure and its descendants.
+
+        Args:
+            chapter: Mapping describing the chapter structure.
+            parent_id: Identifier of the parent container.
+
+        Returns:
+            Generated identifier for the chapter.
+        """
 
         chapter_id = _ensure_id(chapter, "chapter")
         chapter["parent_id"] = parent_id
@@ -150,7 +174,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
         return chapter_id
 
     def process_section(section: Dict[str, Any], parent_id: str) -> str:
-        """Process a section structure and its descendants."""
+        """Process a section structure and its descendants.
+
+        Args:
+            section: Mapping describing the section structure.
+            parent_id: Identifier of the parent container.
+
+        Returns:
+            Generated identifier for the section.
+        """
 
         section_id = _ensure_id(section, "section")
         section["parent_id"] = parent_id
@@ -170,7 +202,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
         return section_id
 
     def process_paragraph(paragraph: Dict[str, Any], parent_id: str) -> str:
-        """Process a paragraph and its substructures."""
+        """Process a paragraph and its substructures.
+
+        Args:
+            paragraph: Mapping describing the paragraph structure.
+            parent_id: Identifier of the parent article.
+
+        Returns:
+            Generated identifier for the paragraph.
+        """
 
         par_id = _ensure_id(paragraph, "par")
         paragraph["parent_id"] = parent_id
@@ -192,7 +232,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
     def process_subparagraph(
         subparagraph: Dict[str, Any], parent_id: str
     ) -> str:
-        """Process a sub-paragraph."""
+        """Process a sub-paragraph.
+
+        Args:
+            subparagraph: Mapping describing the sub-paragraph structure.
+            parent_id: Identifier of the parent paragraph.
+
+        Returns:
+            Generated identifier for the sub-paragraph.
+        """
 
         sub_id = _ensure_id(subparagraph, "sub")
         subparagraph["parent_id"] = parent_id
@@ -201,7 +249,15 @@ def _flatten(doc: Dict[str, Any]) -> Sheets:
         return sub_id
 
     def process_note(note: Dict[str, Any], parent_id: str) -> str:
-        """Process a note attached to an article or paragraph."""
+        """Process a note attached to an article or paragraph.
+
+        Args:
+            note: Mapping describing the note.
+            parent_id: Identifier of the parent element.
+
+        Returns:
+            Generated identifier for the note.
+        """
 
         note_id = _ensure_id(note, "note")
         note["parent_id"] = parent_id


### PR DESCRIPTION
## Summary
- add help text for all Click options and document CLI arguments
- document helper function parameters across parser and LLM modules
- expand workbook utilities with detailed argument docstrings
- remove Click option descriptions from CLI docstrings to avoid duplicate help output

## Testing
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b20292827883279fa230c084ae1351