### PR TITLE
fix: respect orjson API

### DIFF
--- a/leropa/cli.py
+++ b/leropa/cli.py
@@ -1,8 +1,3 @@
-try:
-    import orjson as json  # type: ignore[import-not-found]
-except ImportError:
-    import json
-
 import importlib
 import logging
 import subprocess
@@ -17,6 +12,7 @@ import yaml  # type: ignore
 from dotenv import load_dotenv  # type: ignore[import-not-found]
 
 from leropa import parser
+from leropa.json_utils import json_dumps
 from leropa.xlsx import write_workbook
 
 try:
@@ -115,7 +111,7 @@ def convert(
             final_path = final_path / f"{ver_id}{extensions[output_format]}"
 
     if output_format == "json":
-        content = json.dumps(doc, ensure_ascii=False)
+        content = json_dumps(doc)
         if final_path:
             final_path.write_text(content, encoding="utf-8")
         else:

--- a/leropa/json_utils.py
+++ b/leropa/json_utils.py
@@ -1,0 +1,42 @@
+"""JSON serialization helpers using optional orjson."""
+
+from __future__ import annotations
+
+try:
+    import orjson  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dependency
+    orjson = None  # type: ignore[assignment]
+
+import json
+
+
+def json_dumps(data: object) -> str:
+    """Serialize data to a JSON string.
+
+    Args:
+        data: Data structure to serialize.
+
+    Returns:
+        JSON representation of ``data``.
+    """
+
+    if orjson is not None:
+        return orjson.dumps(data).decode()
+    return json.dumps(data, ensure_ascii=False)
+
+
+def json_loads(data: str | bytes) -> object:
+    """Deserialize JSON data from a string or bytes.
+
+    Args:
+        data: JSON content as ``str`` or ``bytes``.
+
+    Returns:
+        Parsed JSON object.
+    """
+
+    if orjson is not None:
+        return orjson.loads(data)
+    if isinstance(data, (bytes, bytearray)):
+        return json.loads(data.decode())
+    return json.loads(data)

--- a/leropa/llm/rag_legal_qdrant.py
+++ b/leropa/llm/rag_legal_qdrant.py
@@ -74,11 +74,6 @@ import subprocess
 import uuid
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
-try:
-    import orjson as json
-except ImportError:
-    import json  # type: ignore
-
 import requests
 import yaml  # type: ignore[import]
 from qdrant_client import QdrantClient
@@ -92,6 +87,8 @@ from qdrant_client.models import (
     VectorParams,
 )
 from tqdm import tqdm  # type: ignore
+
+from leropa.json_utils import json_loads
 
 # Optional re-ranker (CPU ok). If unavailable, pipeline still works.
 CrossEncoder: Any = None  # ensure bound for type checkers and runtime
@@ -238,12 +235,12 @@ def _read_json_file(path: str) -> List[Dict[str, Any]]:
                 line = line.strip()
                 if not line:
                     continue
-                obj = json.loads(line)
+                obj = json_loads(line)
                 out.append(obj)
         return out
 
     with open(path, "rb") as f:
-        data = json.loads(f.read())
+        data = json_loads(f.read())
 
     return _extract_articles(data)
 
@@ -373,7 +370,7 @@ def _ollama_chat(system: str, user: str, stream: bool = False) -> str:
         try:
             # Ollama streams json lines like:
             #     {"message":{"content":"..."}, "done":false}
-            j = json.loads(line.decode("utf-8"))
+            j = json_loads(line.decode("utf-8"))
             msg = j.get("message", {}).get("content")
             if msg:
                 out.append(msg)

--- a/leropa/xlsx.py
+++ b/leropa/xlsx.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-try:
-    import orjson as json  # type: ignore[import-not-found]
-except ImportError:
-    import json
-
 from pathlib import Path
 from typing import Any, Dict, List
 from uuid import uuid4
@@ -18,6 +13,8 @@ from openpyxl.worksheet.table import (  # type: ignore[import-untyped]
     Table,
     TableStyleInfo,
 )
+
+from leropa.json_utils import json_dumps
 
 Sheets = Dict[str, List[Dict[str, Any]]]
 
@@ -354,7 +351,7 @@ def write_workbook(doc: Dict[str, Any], path: Path) -> None:
                 if isinstance(cell_value, (list, dict)):
                     wrap_columns.add(idx)
                     list_columns.add(idx)
-                    cell_value = json.dumps(cell_value, ensure_ascii=False)
+                    cell_value = json_dumps(cell_value)
 
                 # Mark columns containing long text for wrapping and custom
                 # width.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,7 @@
 """Tests for the command line interface."""
 
-try:
-    import orjson as json  # type: ignore[import-not-found]
-except ImportError:
-    import json
-
 import importlib
+import json
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,49 @@
+"""Tests for JSON utility functions."""
+
+import json
+
+from pytest import MonkeyPatch
+
+from leropa import json_utils
+
+
+def test_json_dumps_without_orjson(monkeypatch: MonkeyPatch) -> None:
+    """Serialize using standard json when orjson is absent."""
+
+    monkeypatch.setattr(json_utils, "orjson", None)
+    data = {"a": 1}
+    assert json_utils.json_dumps(data) == json.dumps(data, ensure_ascii=False)
+
+
+def test_json_dumps_with_orjson(monkeypatch: MonkeyPatch) -> None:
+    """Serialize using orjson when available."""
+
+    class Fake:
+        def dumps(
+            self, obj: object
+        ) -> bytes:  # pragma: no cover - simple stub
+            return b"{}"
+
+    monkeypatch.setattr(json_utils, "orjson", Fake())
+    assert json_utils.json_dumps({}) == "{}"
+
+
+def test_json_loads_without_orjson(monkeypatch: MonkeyPatch) -> None:
+    """Deserialize JSON using standard json when orjson is absent."""
+
+    monkeypatch.setattr(json_utils, "orjson", None)
+    data = {"a": 1}
+    text = json.dumps(data)
+    assert json_utils.json_loads(text) == data
+    assert json_utils.json_loads(text.encode()) == data
+
+
+def test_json_loads_with_orjson(monkeypatch: MonkeyPatch) -> None:
+    """Deserialize JSON using orjson when available."""
+
+    class Fake:
+        def loads(self, data: bytes) -> dict:  # pragma: no cover - simple stub
+            return {"b": 2}
+
+    monkeypatch.setattr(json_utils, "orjson", Fake())
+    assert json_utils.json_loads(b"{}") == {"b": 2}

--- a/tests/test_rag_legal_qdrant.py
+++ b/tests/test_rag_legal_qdrant.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 rag: Any
 try:


### PR DESCRIPTION
## Summary
- provide shared `json_dumps`/`json_loads` helpers that fall back to the stdlib when `orjson` is missing
- refactor CLI, Excel export, and LLM modules to use the centralized JSON utilities
- add unit tests covering both `orjson` and stdlib code paths

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2093a95d48327baabd85556f84f40