### PR TITLE
Add FastAPI web module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@
 - Include article labels parsed from ``S_ART_TTL`` without the ``Articolul``
   prefix.
 - Allow `rag_legal_qdrant` to ingest parser outputs and remove its argparse CLI.
+- Add optional FastAPI module exposing CLI commands as HTTP endpoints.

--- a/leropa/web/__init__.py
+++ b/leropa/web/__init__.py
@@ -1,0 +1,306 @@
+"""FastAPI application exposing CLI commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import yaml  # type: ignore[import-untyped]
+from fastapi import BackgroundTasks, FastAPI, Form, Query, Response
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+)
+
+from leropa import parser
+from leropa.cli import _import_llm_module
+from leropa.xlsx import write_workbook
+
+app = FastAPI()
+
+
+@app.get("/")
+async def chat_form() -> HTMLResponse:
+    """Render a minimal chat form."""
+
+    # Return a simple HTML form for submitting questions.
+    return HTMLResponse(
+        "<form method='post' action='/chat'>"
+        "<input name='question' type='text'/>"
+        "<button type='submit'>Ask</button>"
+        "</form>"
+    )
+
+
+@app.post("/chat")
+async def chat(question: str = Form(...)) -> HTMLResponse:
+    """Handle chat questions and display the answer."""
+
+    # Import the RAG module and generate an answer.
+    mod = _import_llm_module("rag_legal_qdrant")
+    answer = mod.ask_with_context(question, collection="legal_articles")
+
+    # Render the answer in a new HTML page along with the form.
+    return HTMLResponse(
+        f"<p>{answer['text']}</p>"
+        "<form method='post' action='/chat'>"
+        "<input name='question' type='text'/>"
+        "<button type='submit'>Ask</button>"
+        "</form>"
+    )
+
+
+@app.get("/convert")
+async def convert_endpoint(
+    ver_id: str,
+    background_tasks: BackgroundTasks,
+    cache_dir: str | None = Query(default=None),
+    output_format: str = Query(default="json", enum=["json", "yaml", "xlsx"]),
+) -> Response:
+    """Convert a document identifier to structured data.
+
+    Args:
+        ver_id: Identifier for the document version to convert.
+        cache_dir: Directory for the HTML cache.
+        output_format: Desired output format.
+
+    Returns:
+        The structured document in the requested format.
+    """
+
+    # Convert cache path to ``Path`` if provided.
+    cache_path = Path(cache_dir) if cache_dir else None
+
+    # Retrieve and parse the document structure.
+    doc = parser.fetch_document(ver_id, cache_path)
+
+    # Return JSON when requested.
+    if output_format == "json":
+        return JSONResponse(doc)
+
+    # Return YAML output.
+    if output_format == "yaml":
+        text = yaml.safe_dump(doc, allow_unicode=True, sort_keys=False)
+        return PlainTextResponse(text, media_type="application/x-yaml")
+
+    # Prepare XLSX output by writing to a temporary file.
+    tmp = NamedTemporaryFile(suffix=".xlsx", delete=False)
+    write_workbook(doc, Path(tmp.name))
+
+    # Schedule file deletion after the response is sent.
+    background_tasks.add_task(os.unlink, tmp.name)
+
+    # Serve the file as a download.
+    return FileResponse(tmp.name, filename=f"{ver_id}.xlsx")
+
+
+@app.get("/export-md")
+async def export_md_endpoint(
+    input_dir: str,
+    output_dir: str,
+    max_tokens: int = 1000,
+    overlap: int = 200,
+    ext: str = ".md",
+    title_template: str = "Article {label} (ID: {article_id})",
+    body_heading: str = "TEXT",
+) -> JSONResponse:
+    """Export legal JSON articles to chunked Markdown files.
+
+    Args:
+        input_dir: Folder containing JSON or JSONL files.
+        output_dir: Destination folder for Markdown files.
+        max_tokens: Tokens per chunk (0 disables chunking).
+        overlap: Token overlap between chunks.
+        ext: Output file extension.
+        title_template: Title format used in the Markdown output.
+        body_heading: Heading shown before the article text.
+
+    Returns:
+        Summary of the export operation.
+    """
+
+    # Import the exporter module.
+    mod = _import_llm_module("export_legal_articles_to_md")
+
+    # Execute the export and capture resulting counts.
+    art_count, file_count = mod.export_folder(
+        input_dir,
+        output_dir,
+        max_tokens=max_tokens,
+        overlap_tokens=overlap,
+        title_template=title_template,
+        body_heading=body_heading,
+        ext=ext,
+    )
+
+    # Report counts to the caller.
+    return JSONResponse(
+        {
+            "articles": art_count,
+            "files": file_count,
+            "output_dir": output_dir,
+        }
+    )
+
+
+@app.get("/rag/recreate")
+async def rag_recreate(
+    collection: str = "legal_articles",
+    dims: int = 768,
+) -> JSONResponse:
+    """(Re)create the configured Qdrant collection.
+
+    Args:
+        collection: Qdrant collection name.
+        dims: Embedding vector size.
+
+    Returns:
+        Confirmation of the operation.
+    """
+
+    # Import the RAG module and trigger the collection creation.
+    mod = _import_llm_module("rag_legal_qdrant")
+    mod.recreate_collection(collection, vector_size=dims)
+    return JSONResponse({"status": "ready"})
+
+
+@app.get("/rag/ingest")
+async def rag_ingest(
+    folder: str,
+    collection: str = "legal_articles",
+    batch: int = 32,
+    chunk: int = 1000,
+    overlap: int = 200,
+) -> JSONResponse:
+    """Ingest a folder of JSON/JSONL files.
+
+    Args:
+        folder: Path to the directory containing the data files.
+        collection: Qdrant collection name.
+        batch: Batch size for uploads.
+        chunk: Tokens per chunk.
+        overlap: Token overlap between chunks.
+
+    Returns:
+        Number of ingested chunks.
+    """
+
+    # Import the RAG module and process the folder.
+    mod = _import_llm_module("rag_legal_qdrant")
+    total_ingested = mod.ingest_folder(
+        folder,
+        collection=collection,
+        batch_size=batch,
+        chunk_tokens=chunk,
+        overlap_tokens=overlap,
+    )
+    return JSONResponse({"chunks": total_ingested})
+
+
+@app.get("/rag/search")
+async def rag_search(
+    query: str,
+    collection: str = "legal_articles",
+    topk: int = 24,
+    label: str | None = None,
+) -> JSONResponse:
+    """Perform a semantic search over ingested articles.
+
+    Args:
+        query: Query string for semantic search.
+        collection: Qdrant collection name.
+        topk: Number of results to retrieve.
+        label: Filter by article label.
+
+    Returns:
+        Search results from the RAG module.
+    """
+
+    # Import the RAG module and perform the search.
+    mod = _import_llm_module("rag_legal_qdrant")
+    hits = mod.search(query, collection=collection, top_k=topk, label=label)
+    return JSONResponse(hits)
+
+
+@app.get("/rag/ask")
+async def rag_ask(
+    question: str,
+    collection: str = "legal_articles",
+    topk: int = 24,
+    finalk: int = 8,
+    no_rerank: bool = False,
+) -> JSONResponse:
+    """Ask a question and receive an answer with context.
+
+    Args:
+        question: The question to ask the model.
+        collection: Qdrant collection name.
+        topk: Number of documents to retrieve.
+        finalk: Number of documents to include in the final context.
+        no_rerank: Disable the re-ranker when True.
+
+    Returns:
+        Generated answer and its contexts.
+    """
+
+    # Import the RAG module and get the answer with context.
+    mod = _import_llm_module("rag_legal_qdrant")
+    answer = mod.ask_with_context(
+        question,
+        collection=collection,
+        top_k=topk,
+        final_k=finalk,
+        use_reranker=not no_rerank,
+    )
+    return JSONResponse(answer)
+
+
+@app.delete("/rag/delete")
+async def rag_delete(
+    article_id: str,
+    collection: str = "legal_articles",
+) -> JSONResponse:
+    """Delete items from the collection by ``article_id``.
+
+    Args:
+        article_id: Identifier of the article to remove.
+        collection: Qdrant collection name.
+
+    Returns:
+        Number of deleted points.
+    """
+
+    # Import the RAG module and perform the deletion.
+    mod = _import_llm_module("rag_legal_qdrant")
+    total_deleted = mod.delete_by_article_id(article_id, collection=collection)
+    return JSONResponse({"deleted": total_deleted})
+
+
+@app.get("/rag/start-qdrant")
+async def rag_start_qdrant(
+    name: str = "qdrant",
+    port: int = 6333,
+    volume: str = "qdrant_storage",
+    image: str = "qdrant/qdrant:latest",
+) -> JSONResponse:
+    """Attempt to start Qdrant via Docker.
+
+    Args:
+        name: Docker container name.
+        port: Qdrant port to expose.
+        volume: Docker volume for persistent storage.
+        image: Docker image to run.
+
+    Returns:
+        Whether the container was started successfully.
+    """
+
+    # Import the RAG module and start the Docker container.
+    mod = _import_llm_module("rag_legal_qdrant")
+    result = mod.start_qdrant_docker(
+        name=name, port=port, volume=volume, image=image
+    )
+    return JSONResponse({"started": bool(result)})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ llm = [
   "sentence-transformers>=2.2.2,<3",
   "tqdm>=4.67.1",
 ]
+fastapi = [
+  "fastapi>=0.111,<1",
+  "uvicorn>=0.30,<1",
+]
 
 
 [build-system]

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -19,8 +19,12 @@ def test_json_dumps_with_orjson(monkeypatch: MonkeyPatch) -> None:
     """Serialize using orjson when available."""
 
     class Fake:
+        """Stub ``orjson`` module used in tests."""
+
+        OPT_INDENT_2 = 2
+
         def dumps(
-            self, obj: object
+            self, obj: object, option: int
         ) -> bytes:  # pragma: no cover - simple stub
             return b"{}"
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,67 @@
+"""Tests for FastAPI web module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from leropa import parser
+from leropa.web import app
+
+JSONDict = Dict[str, Any]
+
+
+def _client() -> TestClient:
+    """Return a test client for the web app."""
+
+    # Create and return a test client for the FastAPI application.
+    return TestClient(app)
+
+
+def test_convert_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Endpoint should return parsed document data as JSON."""
+
+    # Provide a fake implementation for ``fetch_document`` to avoid network.
+    def fake_fetch(ver_id: str, cache_path: Path | None) -> JSONDict:
+        return {"ver_id": ver_id}
+
+    monkeypatch.setattr(parser, "fetch_document", fake_fetch)
+
+    client = _client()
+    response = client.get("/convert", params={"ver_id": "123"})
+
+    # Ensure the mocked data is returned.
+    assert response.status_code == 200
+    assert response.json() == {"ver_id": "123"}
+
+
+def test_chat_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chat form should display the generated answer."""
+
+    class FakeModule:
+        """Stub rag module used for tests."""
+
+        @staticmethod
+        def ask_with_context(
+            question: str,
+            collection: str,
+            top_k: int = 24,
+            final_k: int = 8,
+            use_reranker: bool = True,
+        ) -> JSONDict:
+            return {"text": f"Echo: {question}", "contexts": []}
+
+    # Replace the module loader with our stub implementation.
+    monkeypatch.setattr(
+        "leropa.web._import_llm_module", lambda name: FakeModule, raising=False
+    )
+
+    client = _client()
+    response = client.post("/chat", data={"question": "Hi"})
+
+    # Verify that the answer from the stub is present in the response.
+    assert response.status_code == 200
+    assert "Echo: Hi" in response.text


### PR DESCRIPTION
## Summary
- add optional FastAPI extra
- expose CLI commands through a FastAPI app and chat form
- cover web module with tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b21f7807148327bcbcaf8fcb23b80c