### PR TITLE
Handle optional FastAPI dependency

### DIFF
--- a/leropa/cli.py
+++ b/leropa/cli.py
@@ -13,8 +13,8 @@ from dotenv import load_dotenv  # type: ignore[import-not-found]
 
 from leropa import parser
 from leropa.json_utils import json_dumps
-from leropa.xlsx import write_workbook
 from leropa.llm import available_models
+from leropa.xlsx import write_workbook
 
 try:
     __version__ = version("leropa")

--- a/leropa/web/__init__.py
+++ b/leropa/web/__init__.py
@@ -7,8 +7,14 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import yaml  # type: ignore[import-untyped]
-from fastapi import BackgroundTasks, FastAPI, Form, Query, Response
-from fastapi.responses import (
+from fastapi import (  # type: ignore[import-not-found]
+    BackgroundTasks,
+    FastAPI,
+    Form,
+    Query,
+    Response,
+)
+from fastapi.responses import (  # type: ignore[import-not-found]
     FileResponse,
     HTMLResponse,
     JSONResponse,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 import yaml  # type: ignore[import-untyped]
 from click.testing import CliRunner
 from openpyxl import load_workbook  # type: ignore[import-untyped]
@@ -413,7 +414,7 @@ def test_rag_recreate_invokes_module() -> None:
     assert called["vector_size"] == 10
 
 
-def test_models_command_lists_models(monkeypatch) -> None:
+def test_models_command_lists_models(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure the models command prints available model names."""
 
     # Return a predictable list of models.
@@ -425,7 +426,7 @@ def test_models_command_lists_models(monkeypatch) -> None:
     assert "m2" in result.output
 
 
-def test_rag_respects_model_option(monkeypatch) -> None:
+def test_rag_respects_model_option(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure rag commands import the user-selected model."""
 
     loaded: dict[str, str] = {}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typing import Any, Dict
 
 import pytest
-from fastapi.testclient import TestClient
+
+pytest.importorskip("fastapi.testclient")
+
+from fastapi.testclient import TestClient  # type: ignore[import-not-found]
 
 from leropa import parser
 from leropa.web import app
@@ -98,13 +101,13 @@ def test_chat_endpoint_uses_selected_model(
     class FakeModule:
         @staticmethod
         def ask_with_context(
-            question: str, collection: str, **_: Any
+            question: str, collection: str, **_: object
         ) -> JSONDict:
             return {"text": f"Echo: {question}", "contexts": []}
 
     imported: dict[str, str] = {}
 
-    def fake_loader(name: str) -> Any:
+    def fake_loader(name: str) -> type[FakeModule]:
         imported["name"] = name
         return FakeModule
 


### PR DESCRIPTION
## Summary
- silence mypy missing import errors for FastAPI
- skip FastAPI web tests when the dependency isn't installed
- add pytest type hints and sort imports to satisfy linters

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b296a2ee308327aab48075d769b50d