### PR TITLE
feat(web): list and view cached documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 - Allow `rag_legal_qdrant` to ingest parser outputs and remove its argparse CLI.
 - Add optional FastAPI module exposing CLI commands as HTTP endpoints.
 - List available LLM models and allow selecting the model via CLI and web API.
+- Expose endpoints to list and view structured documents via FastAPI.


### PR DESCRIPTION
## Summary
- expose `/documents` to list cached YAML/JSON documents
- expose `/documents/{ver_id}` to display a document without `full_text`
- describe new HTTP endpoints in the changelog

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a5169af88327aba206c67d97e804