### PR TITLE
Query Ollama for available models

### DIFF
--- a/leropa/llm/__init__.py
+++ b/leropa/llm/__init__.py
@@ -2,31 +2,47 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+
+import requests
 
 # Alias for a list of strings used for model names.
 StrList = list[str]
 
 
-def available_models() -> StrList:
-    """Return available LLM model modules.
+# Default endpoint for listing models on the local Ollama server.
+OLLAMA_TAGS_URL = os.environ.get(
+    "OLLAMA_TAGS_URL", "http://localhost:11434/api/tags"
+)
 
-    Scans the ``leropa.llm`` package for Python modules and returns their
-    names sorted alphabetically.
+
+def available_models() -> StrList:
+    """Return model names available on the Ollama server.
 
     Returns:
-        Sorted list of module names.
+        Sorted list of model names reported by the Ollama server. If the
+        server cannot be reached or provides unexpected data, an empty list is
+        returned.
     """
 
-    # Locate the directory containing LLM modules.
-    package_dir = Path(__file__).parent
+    try:
+        # Request the list of models from the Ollama API.
+        response = requests.get(OLLAMA_TAGS_URL, timeout=5)
 
-    # Gather all Python files except ``__init__`` and private ones.
-    modules = [
-        path.stem
-        for path in package_dir.glob("[!_]*.py")
-        if path.stem != "__init__"
+        # Raise for HTTP errors (4xx, 5xx) to trigger the exception handler.
+        response.raise_for_status()
+
+        # Parse the JSON payload.
+        payload = response.json()
+    except Exception:
+        # In case of network errors or invalid responses, assume no models are
+        # available to keep the caller logic simple.
+        return []
+
+    # Extract model names from the response, ignoring malformed entries.
+    models = [
+        m.get("name", "") for m in payload.get("models", []) if m.get("name")
     ]
 
-    # Return a deterministic list of module names.
-    return sorted(modules)
+    # Return a deterministic list of model names.
+    return sorted(models)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,35 @@
+"""Tests for the LLM utilities."""
+
+from types import SimpleNamespace
+
+import pytest
+import requests  # type: ignore[import-untyped]
+
+from leropa.llm import available_models
+
+
+def test_available_models_queries_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure available_models returns sorted names from the server."""
+
+    def fake_get(url: str, timeout: int = 5) -> SimpleNamespace:
+        return SimpleNamespace(
+            json=lambda: {"models": [{"name": "b"}, {"name": "a"}]},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert available_models() == ["a", "b"]
+
+
+def test_available_models_handles_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure available_models returns an empty list on failure."""
+
+    def fake_get(*_: object, **__: object) -> SimpleNamespace:
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert available_models() == []


### PR DESCRIPTION
## Summary
- query the Ollama API for model names via `available_models`
- cover model discovery with new unit tests

## Testing
- `make format`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc06ac90832781460515d2aee6bb