### PR TITLE
feat: add jinja templates for document views

### DIFF
--- a/leropa/web/routes/document_detail.py
+++ b/leropa/web/routes/document_detail.py
@@ -6,18 +6,16 @@ from fastapi import (  # type: ignore[import-not-found]
     APIRouter,
     HTTPException,
     Query,
+    Request,
     Response,
 )
-from fastapi.responses import (  # type: ignore[import-not-found]
-    HTMLResponse,
-    JSONResponse,
-)
+from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 
 from ..utils import (
     _document_files,
     _load_document_file,
-    _render_document,
     _strip_full_text,
+    templates,
 )
 
 router = APIRouter()
@@ -26,12 +24,14 @@ router = APIRouter()
 @router.get("/documents/{ver_id}")
 async def get_document(
     ver_id: str,
+    request: Request,
     format: str = Query(default="json", enum=["json", "html"]),
 ) -> Response:
     """Return a specific document by version identifier.
 
     Args:
         ver_id: Document version identifier.
+        request: Incoming request used for template rendering.
         format: Desired response format.
 
     Returns:
@@ -47,6 +47,8 @@ async def get_document(
 
     # Render as HTML when requested.
     if format == "html":
-        return HTMLResponse(_render_document(doc))
+        return templates.TemplateResponse(
+            "document_detail.html", {"request": request, "doc": doc}
+        )
 
     return JSONResponse(doc)

--- a/leropa/web/routes/documents.py
+++ b/leropa/web/routes/documents.py
@@ -5,25 +5,30 @@ from __future__ import annotations
 from fastapi import (  # type: ignore[import-not-found]
     APIRouter,
     Query,
+    Request,
     Response,
 )
-from fastapi.responses import (  # type: ignore[import-not-found]
-    HTMLResponse,
-    JSONResponse,
-)
+from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 
-from ..utils import DocumentSummaryList, _document_files, _load_document_file
+from ..utils import (
+    DocumentSummaryList,
+    _document_files,
+    _load_document_file,
+    templates,
+)
 
 router = APIRouter()
 
 
 @router.get("/documents")
 async def list_documents(
+    request: Request,
     format: str = Query(default="json", enum=["json", "html"]),
 ) -> Response:
     """List structured documents available on the server.
 
     Args:
+        request: Incoming request used for template rendering.
         format: Desired response format.
 
     Returns:
@@ -41,13 +46,8 @@ async def list_documents(
 
     # Render as HTML when requested.
     if format == "html":
-        template = (
-            "<li><a href='/documents/{ver}?format=html'>{title}</a></li>"
+        return templates.TemplateResponse(
+            "documents.html", {"request": request, "documents": summaries}
         )
-        items = "".join(
-            template.format(ver=s["ver_id"], title=s["title"])
-            for s in summaries
-        )
-        return HTMLResponse(f"<ul>{items}</ul>")
 
     return JSONResponse(summaries)

--- a/leropa/web/templates/base.html
+++ b/leropa/web/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{{ title or "Leropa" }}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIAtI3XvLZJgCevne7y1AwBXN90fK4e12G5LM715S4um5Cyn0Ux2C0rU0" crossorigin="anonymous" />
+</head>
+<body>
+  <div class="container py-4">
+    {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/leropa/web/templates/document_detail.html
+++ b/leropa/web/templates/document_detail.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ doc.document.title }}</h1>
+
+{% macro render_part(part) %}
+  <div class="ms-3">
+    {% if part.title %}
+      <h2>{{ part.title }}</h2>
+    {% endif %}
+    {% if part.label and part.text %}
+      <p><strong>{{ part.label }}</strong> {{ part.text }}</p>
+    {% elif part.text %}
+      <p>{{ part.text }}</p>
+    {% endif %}
+    {% for key in [
+      'books', 'titles', 'chapters', 'sections',
+      'articles', 'paragraphs', 'subparagraphs', 'annexes'] %}
+      {% for child in part.get(key, []) %}
+        {{ render_part(child) }}
+      {% endfor %}
+    {% endfor %}
+  </div>
+{% endmacro %}
+
+{% for key in ['books', 'articles', 'annexes'] %}
+  {% for item in doc.get(key, []) %}
+    {{ render_part(item) }}
+  {% endfor %}
+{% endfor %}
+{% endblock %}

--- a/leropa/web/templates/documents.html
+++ b/leropa/web/templates/documents.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Documents</h1>
+<ul class="list-group">
+  {% for doc in documents %}
+    <li class="list-group-item">
+      <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/leropa/web/utils.py
+++ b/leropa/web/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
+from fastapi.templating import Jinja2Templates  # type: ignore
 
 from leropa.json_utils import json_loads
 
@@ -18,6 +19,12 @@ DocumentSummaryList = list[DocumentSummary]
 DOCUMENTS_DIR = Path(
     os.environ.get("LEROPA_DOCUMENTS", Path.home() / ".leropa" / "documents")
 )
+
+# Location of Jinja2 templates used by the web application.
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+
+# Jinja2 template renderer shared by route handlers.
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 
 def _document_files() -> list[Path]:
@@ -70,33 +77,3 @@ def _strip_full_text(doc: JSONDict) -> JSONDict:
     for article in doc.get("articles", []):
         article.pop("full_text", None)
     return doc
-
-
-def _render_document(doc: JSONDict) -> str:
-    """Render a document structure into basic HTML.
-
-    Args:
-        doc: Parsed document data.
-
-    Returns:
-        HTML string representing the document.
-    """
-
-    parts = [f"<h1>{doc['document'].get('title', '')}</h1>"]
-
-    # Render each article with its paragraphs and subparagraphs.
-    for article in doc.get("articles", []):
-        label = article.get("label", article.get("article_id", ""))
-        parts.append(f"<h2>Art. {label}</h2>")
-
-        for paragraph in article.get("paragraphs", []):
-            par_label = paragraph.get("label", "")
-            text = paragraph.get("text", "")
-            parts.append(f"<p>{par_label} {text}</p>")
-
-            # Include subparagraphs when present.
-            for sub in paragraph.get("subparagraphs", []):
-                sub_label = sub.get("label", "")
-                sub_text = sub.get("text", "")
-                parts.append(f"<p>{sub_label} {sub_text}</p>")
-    return "".join(parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ llm = [
 fastapi = [
   "fastapi>=0.111,<1",
   "uvicorn>=0.30,<1",
+  "jinja2>=3.1,<4",
 ]
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -193,12 +193,24 @@ def test_document_endpoints(
     assert {"ver_id": "1", "title": "Doc1"} in docs
     assert {"ver_id": "2", "title": "Doc2"} in docs
 
+    # HTML listing should include both titles.
+    response = client.get("/documents", params={"format": "html"})
+    assert response.status_code == 200
+    assert "Doc1" in response.text
+    assert "Doc2" in response.text
+
     # Fetching a document should strip ``full_text``.
     response = client.get("/documents/1")
     assert response.status_code == 200
     data = response.json()
     assert "full_text" not in data["articles"][0]
     assert data["articles"][0]["paragraphs"][0]["text"] == "P"
+
+    # HTML rendering should contain the article text.
+    response = client.get("/documents/1", params={"format": "html"})
+    assert response.status_code == 200
+    assert "Doc1" in response.text
+    assert "P" in response.text
 
 
 def test_export_md_endpoint(


### PR DESCRIPTION
## Summary
- use Jinja templates with Bootstrap to render document list and detail pages
- share Jinja2 template loader
- add jinja2 dependency for fastapi extras

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf217d6c83278732b6ed0588504f