### PR TITLE
Simplify model imports in web routes

### DIFF
--- a/leropa/web/routes/export_md.py
+++ b/leropa/web/routes/export_md.py
@@ -9,6 +9,9 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the exporter module once; it exposes ``export_folder``.
+_EXPORTER = _import_llm_module("export_legal_articles_to_md")
+
 
 @router.get("/export-md")
 async def export_md_endpoint(
@@ -19,7 +22,6 @@ async def export_md_endpoint(
     ext: str = ".md",
     title_template: str = "Article {label} (ID: {article_id})",
     body_heading: str = "TEXT",
-    model: str = "export_legal_articles_to_md",
 ) -> JSONResponse:
     """Export legal JSON articles to chunked Markdown files.
 
@@ -36,11 +38,8 @@ async def export_md_endpoint(
         Summary of the export operation.
     """
 
-    # Import the requested exporter module.
-    mod = _import_llm_module(model)
-
     # Execute the export and capture resulting counts.
-    art_count, file_count = mod.export_folder(
+    art_count, file_count = _EXPORTER.export_folder(
         input_dir,
         output_dir,
         max_tokens=max_tokens,

--- a/leropa/web/routes/rag_ask.py
+++ b/leropa/web/routes/rag_ask.py
@@ -9,6 +9,9 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once; used for answering questions.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.get("/rag/ask")
 async def rag_ask(
@@ -17,7 +20,6 @@ async def rag_ask(
     topk: int = 24,
     finalk: int = 8,
     no_rerank: bool = False,
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """Ask a question and receive an answer with context.
 
@@ -32,9 +34,8 @@ async def rag_ask(
         Generated answer and its contexts.
     """
 
-    # Import the requested RAG module and get the answer with context.
-    mod = _import_llm_module(model)
-    answer = mod.ask_with_context(
+    # Get the answer with context using the RAG helper.
+    answer = _RAG.ask_with_context(
         question,
         collection=collection,
         top_k=topk,

--- a/leropa/web/routes/rag_delete.py
+++ b/leropa/web/routes/rag_delete.py
@@ -9,12 +9,14 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once for collection operations.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.delete("/rag/delete")
 async def rag_delete(
     article_id: str,
     collection: str = "legal_articles",
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """Delete items from the collection by ``article_id``.
 
@@ -26,7 +28,8 @@ async def rag_delete(
         Number of deleted points.
     """
 
-    # Import the requested RAG module and perform the deletion.
-    mod = _import_llm_module(model)
-    total_deleted = mod.delete_by_article_id(article_id, collection=collection)
+    # Perform the deletion using the RAG helper.
+    total_deleted = _RAG.delete_by_article_id(
+        article_id, collection=collection
+    )
     return JSONResponse({"deleted": total_deleted})

--- a/leropa/web/routes/rag_ingest.py
+++ b/leropa/web/routes/rag_ingest.py
@@ -9,6 +9,9 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once; used for ingestion operations.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.get("/rag/ingest")
 async def rag_ingest(
@@ -17,7 +20,6 @@ async def rag_ingest(
     batch: int = 32,
     chunk: int = 1000,
     overlap: int = 200,
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """Ingest a folder of JSON/JSONL files.
 
@@ -32,9 +34,8 @@ async def rag_ingest(
         Number of ingested chunks.
     """
 
-    # Import the requested RAG module and process the folder.
-    mod = _import_llm_module(model)
-    total_ingested = mod.ingest_folder(
+    # Process the folder using the RAG helper.
+    total_ingested = _RAG.ingest_folder(
         folder,
         collection=collection,
         batch_size=batch,

--- a/leropa/web/routes/rag_recreate.py
+++ b/leropa/web/routes/rag_recreate.py
@@ -9,12 +9,14 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once for collection maintenance.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.get("/rag/recreate")
 async def rag_recreate(
     collection: str = "legal_articles",
     dims: int = 768,
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """(Re)create the configured Qdrant collection.
 
@@ -26,7 +28,6 @@ async def rag_recreate(
         Confirmation of the operation.
     """
 
-    # Import the requested RAG module and trigger the collection creation.
-    mod = _import_llm_module(model)
-    mod.recreate_collection(collection, vector_size=dims)
+    # Trigger the collection creation using the RAG helper.
+    _RAG.recreate_collection(collection, vector_size=dims)
     return JSONResponse({"status": "ready"})

--- a/leropa/web/routes/rag_search.py
+++ b/leropa/web/routes/rag_search.py
@@ -9,6 +9,9 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once; used for search operations.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.get("/rag/search")
 async def rag_search(
@@ -16,7 +19,6 @@ async def rag_search(
     collection: str = "legal_articles",
     topk: int = 24,
     label: str | None = None,
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """Perform a semantic search over ingested articles.
 
@@ -30,7 +32,6 @@ async def rag_search(
         Search results from the RAG module.
     """
 
-    # Import the requested RAG module and perform the search.
-    mod = _import_llm_module(model)
-    hits = mod.search(query, collection=collection, top_k=topk, label=label)
+    # Perform the search using the RAG helper.
+    hits = _RAG.search(query, collection=collection, top_k=topk, label=label)
     return JSONResponse(hits)

--- a/leropa/web/routes/rag_start_qdrant.py
+++ b/leropa/web/routes/rag_start_qdrant.py
@@ -9,6 +9,9 @@ from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+# Load the RAG module once; used for utility operations.
+_RAG = _import_llm_module("rag_legal_qdrant")
+
 
 @router.get("/rag/start-qdrant")
 async def rag_start_qdrant(
@@ -16,7 +19,6 @@ async def rag_start_qdrant(
     port: int = 6333,
     volume: str = "qdrant_storage",
     image: str = "qdrant/qdrant:latest",
-    model: str = "rag_legal_qdrant",
 ) -> JSONResponse:
     """Attempt to start Qdrant via Docker.
 
@@ -30,9 +32,8 @@ async def rag_start_qdrant(
         Whether the container was started successfully.
     """
 
-    # Import the requested RAG module and start the Docker container.
-    mod = _import_llm_module(model)
-    result = mod.start_qdrant_docker(
+    # Start the Docker container using the RAG helper.
+    result = _RAG.start_qdrant_docker(
         name=name, port=port, volume=volume, image=image
     )
     return JSONResponse({"started": bool(result)})


### PR DESCRIPTION
## Summary
- Load RAG and exporter helpers once per route instead of importing arbitrary modules
- Treat chat model selection as an Ollama model and set `GEN_MODEL` on the RAG helper
- Adjust tests for new helper stubs

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c28be18c8327a61c49401ddaca7b