### PR TITLE
feat(web): add template-based root page

### DIFF
--- a/leropa/web/routes/rag_search.py
+++ b/leropa/web/routes/rag_search.py
@@ -4,34 +4,42 @@ from __future__ import annotations
 
 from fastapi import APIRouter  # type: ignore[import-not-found]
 from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
+from pydantic import BaseModel  # type: ignore[import-not-found]
 
 from leropa.cli import _import_llm_module
 
 router = APIRouter()
 
+
+class SearchRequest(BaseModel):
+    """Input payload for the search endpoint."""
+
+    query: str
+    collection: str = "legal_articles"
+    topk: int = 24
+    label: str | None = None
+
+
 # Load the RAG module once; used for search operations.
 _RAG = _import_llm_module("rag_legal_qdrant")
 
 
-@router.get("/rag/search")
-async def rag_search(
-    query: str,
-    collection: str = "legal_articles",
-    topk: int = 24,
-    label: str | None = None,
-) -> JSONResponse:
+@router.api_route("/rag/search", methods=["GET", "POST"])
+async def rag_search(payload: SearchRequest) -> JSONResponse:
     """Perform a semantic search over ingested articles.
 
     Args:
-        query: Query string for semantic search.
-        collection: Qdrant collection name.
-        topk: Number of results to retrieve.
-        label: Filter by article label.
+        payload: Parameters controlling the search.
 
     Returns:
         Search results from the RAG module.
     """
 
     # Perform the search using the RAG helper.
-    hits = _RAG.search(query, collection=collection, top_k=topk, label=label)
+    hits = _RAG.search(
+        payload.query,
+        collection=payload.collection,
+        top_k=payload.topk,
+        label=payload.label,
+    )
     return JSONResponse(hits)

--- a/leropa/web/routes/root.py
+++ b/leropa/web/routes/root.py
@@ -1,30 +1,25 @@
-"""Root page displaying a chat form."""
+"""Root page displaying the RAG interface."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter  # type: ignore[import-not-found]
+from fastapi import APIRouter, Request  # type: ignore[import-not-found]
 from fastapi.responses import HTMLResponse  # type: ignore[import-not-found]
 
-from leropa.llm import available_models
+from ..utils import templates
 
 router = APIRouter()
 
 
 @router.get("/")
-async def chat_form() -> HTMLResponse:
-    """Render a minimal chat form."""
+async def root_page(request: Request) -> HTMLResponse:
+    """Render the main page with chat and search forms.
 
-    # Build options for all available models.
-    model_opts = "".join(
-        f"<option value='{name}'>{name}</option>"
-        for name in available_models()
-    )
+    Args:
+        request: Incoming request used for template rendering.
 
-    # Return a simple HTML form for submitting questions and selecting a model.
-    return HTMLResponse(
-        "<form method='post' action='/chat'>"
-        f"<select name='model'>{model_opts}</select>"
-        "<input name='question' type='text'/>"
-        "<button type='submit'>Ask</button>"
-        "</form>"
-    )
+    Returns:
+        Rendered HTML page.
+    """
+
+    # Render the Jinja2 template for the main page.
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/leropa/web/templates/index.html
+++ b/leropa/web/templates/index.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Leropa RAG Demo</h1>
+<p><a href="/documents?format=html">Documents</a></p>
+
+<div class="mb-4">
+  <h2>Ask a question</h2>
+  <form id="ask-form" class="row g-3">
+    <div class="col-auto flex-grow-1">
+      <input id="question" name="question" class="form-control" placeholder="Your question" />
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-primary" type="submit">Ask</button>
+    </div>
+  </form>
+  <pre id="answer" class="mt-3 bg-light p-3"></pre>
+</div>
+
+<div class="mb-4">
+  <h2>Search documents</h2>
+  <form id="search-form" class="row g-3">
+    <div class="col-auto flex-grow-1">
+      <input id="query" name="query" class="form-control" placeholder="Search query" />
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-secondary" type="submit">Search</button>
+    </div>
+  </form>
+  <ul id="hits" class="list-group mt-3"></ul>
+</div>
+
+<script>
+const askForm = document.getElementById('ask-form');
+askForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const question = document.getElementById('question').value;
+  const resp = await fetch('/rag/ask', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({question})
+  });
+  const data = await resp.json();
+  document.getElementById('answer').textContent = data.text || '';
+});
+
+const searchForm = document.getElementById('search-form');
+searchForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const query = document.getElementById('query').value;
+  const resp = await fetch('/rag/search', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({query})
+  });
+  const hits = await resp.json();
+  const list = document.getElementById('hits');
+  list.innerHTML = '';
+  hits.forEach((hit) => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = hit.text || JSON.stringify(hit);
+    list.appendChild(li);
+  });
+});
+</script>
+{% endblock %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -87,17 +87,13 @@ def test_models_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.json() == ["m1", "m2"]
 
 
-def test_chat_form_lists_models(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The chat form should offer model choices."""
+def test_root_page_links_documents() -> None:
+    """Root page should link to the documents listing."""
 
-    monkeypatch.setattr(
-        "leropa.web.routes.root.available_models", lambda: ["m1", "m2"]
-    )
     client = _client()
     response = client.get("/")
     assert response.status_code == 200
-    assert "<option value='m1'>" in response.text
-    assert "<option value='m2'>" in response.text
+    assert '<a href="/documents?format=html"' in response.text
 
 
 def test_chat_endpoint_uses_selected_model(
@@ -311,8 +307,15 @@ def test_rag_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
         == "hit"
     )
     assert (
+        client.post("/rag/search", json={"query": "q"}).json()[0]["text"]
+        == "hit"
+    )
+    assert (
         client.get("/rag/ask", params={"question": "q"}).json()["text"]
         == "ans"
+    )
+    assert (
+        client.post("/rag/ask", json={"question": "q"}).json()["text"] == "ans"
     )
     assert (
         client.delete("/rag/delete", params={"article_id": "a"}).json()[


### PR DESCRIPTION
## Summary
- serve a Bootstrap-styled index template at `/`
- accept POST requests on `/rag/ask` and `/rag/search`
- verify root page link and POST routes with new tests

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c4de7c708327a421c41e56b7f1d2