### PR TITLE
Handle fetch errors with toast notifications

### DIFF
--- a/leropa/web/templates/base.html
+++ b/leropa/web/templates/base.html
@@ -9,5 +9,39 @@
   <div class="container py-4">
     {% block content %}{% endblock %}
   </div>
+
+  <div class="toast-container position-fixed top-0 end-0 p-3" id="toast-container"></div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60M0OrSOxxOnI50ofGLumZ5qX6Om12emsIfsetELuoDt/7EGGh" crossorigin="anonymous"></script>
+  <script>
+    // Display a Bootstrap toast with the provided message.
+
+    function showToast(message) {
+      // Locate the container that holds all toasts.
+
+      const container = document.getElementById('toast-container');
+
+      // Build a toast element with error styling.
+
+      const toastEl = document.createElement('div');
+      toastEl.className = 'toast align-items-center text-bg-danger border-0';
+      toastEl.setAttribute('role', 'alert');
+      toastEl.setAttribute('aria-live', 'assertive');
+      toastEl.setAttribute('aria-atomic', 'true');
+      toastEl.innerHTML = `
+        <div class="d-flex">
+          <div class="toast-body">${message}</div>
+          <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>`;
+
+      // Append the toast to the container.
+
+      container.appendChild(toastEl);
+
+      // Show the toast using Bootstrap's API.
+
+      const toast = new bootstrap.Toast(toastEl);
+      toast.show();
+    }
+  </script>
 </body>
 </html>

--- a/leropa/web/templates/index.html
+++ b/leropa/web/templates/index.html
@@ -33,34 +33,78 @@
 const askForm = document.getElementById('ask-form');
 askForm.addEventListener('submit', async (e) => {
   e.preventDefault();
+
+  // Read the question from the input field.
+
   const question = document.getElementById('question').value;
-  const resp = await fetch('/rag/ask', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({question})
-  });
-  const data = await resp.json();
-  document.getElementById('answer').textContent = data.text || '';
+
+  try {
+    // Perform a POST request to the ask endpoint.
+
+    const resp = await fetch('/rag/ask', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({question}),
+    });
+
+    // Throw an error if the response is not successful.
+
+    if (!resp.ok) {
+      const errText = await resp.text();
+      throw new Error(errText || resp.statusText);
+    }
+
+    // Parse the JSON answer and display it to the user.
+
+    const data = await resp.json();
+    document.getElementById('answer').textContent = data.text || '';
+  } catch (err) {
+    // Show a toast notification for any errors.
+
+    showToast(err.message);
+  }
 });
 
 const searchForm = document.getElementById('search-form');
 searchForm.addEventListener('submit', async (e) => {
   e.preventDefault();
+
+  // Read the search query from the input field.
+
   const query = document.getElementById('query').value;
-  const resp = await fetch('/rag/search', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({query})
-  });
-  const hits = await resp.json();
-  const list = document.getElementById('hits');
-  list.innerHTML = '';
-  hits.forEach((hit) => {
-    const li = document.createElement('li');
-    li.className = 'list-group-item';
-    li.textContent = hit.text || JSON.stringify(hit);
-    list.appendChild(li);
-  });
+
+  try {
+    // Perform a POST request to the search endpoint.
+
+    const resp = await fetch('/rag/search', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query}),
+    });
+
+    // Throw an error if the response is not successful.
+
+    if (!resp.ok) {
+      const errText = await resp.text();
+      throw new Error(errText || resp.statusText);
+    }
+
+    // Parse the JSON hits and populate the list with results.
+
+    const hits = await resp.json();
+    const list = document.getElementById('hits');
+    list.innerHTML = '';
+    hits.forEach((hit) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      li.textContent = hit.text || JSON.stringify(hit);
+      list.appendChild(li);
+    });
+  } catch (err) {
+    // Show a toast notification for any errors.
+
+    showToast(err.message);
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load Bootstrap's JS bundle and implement a reusable `showToast` helper
- show a toast when `/rag/ask` or `/rag/search` fetch requests fail

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c9658dac8327a84153f8b77b8a70