### PR TITLE
feat: add raw document post routes

### DIFF
--- a/leropa/web/routes/document_detail.py
+++ b/leropa/web/routes/document_detail.py
@@ -52,3 +52,33 @@ async def get_document(
         )
 
     return JSONResponse(doc)
+
+
+@router.post("/documents/{ver_id}")
+async def get_document_raw(ver_id: str) -> Response:
+    """Return the raw content of a document file.
+
+    Args:
+        ver_id: Document version identifier.
+
+    Returns:
+        Raw text of the document's JSON or YAML file.
+    """
+
+    # Locate the document file matching ``ver_id``.
+    file_path = next((p for p in _document_files() if p.stem == ver_id), None)
+    if file_path is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    # Read the file contents as text.
+    text = file_path.read_text(encoding="utf-8")
+
+    # Choose response media type based on file extension.
+    media_type = (
+        "application/json"
+        if file_path.suffix == ".json"
+        else "application/x-yaml"
+    )
+
+    # Return the raw document text.
+    return Response(content=text, media_type=media_type)

--- a/leropa/web/routes/documents.py
+++ b/leropa/web/routes/documents.py
@@ -51,3 +51,29 @@ async def list_documents(
         )
 
     return JSONResponse(summaries)
+
+
+@router.post("/documents")
+async def list_documents_raw() -> JSONResponse:
+    """Return raw list of document identifiers and titles.
+
+    Returns:
+        List of document summaries.
+    """
+
+    # Initialize list for summary entries.
+    summaries: DocumentSummaryList = []
+
+    # Iterate through all known document files.
+    for path in _document_files():
+        # Read document structure from disk.
+        data = _load_document_file(path)
+        info = data.get("document", {})
+
+        # Record identifier and title.
+        summaries.append(
+            {"ver_id": info.get("ver_id"), "title": info.get("title")}
+        )
+
+    # Return collected summaries as JSON.
+    return JSONResponse(summaries)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -200,6 +200,25 @@ def test_document_endpoints(
     assert "Doc1" in response.text
     assert "P" in response.text
 
+    # POST listing should return raw summaries.
+    response = client.post("/documents")
+    assert response.status_code == 200
+    docs = response.json()
+    assert {"ver_id": "1", "title": "Doc1"} in docs
+    assert {"ver_id": "2", "title": "Doc2"} in docs
+
+    # POST detail should return raw JSON content.
+    response = client.post("/documents/1")
+    assert response.status_code == 200
+    assert response.text == (tmp_path / "1.json").read_text()
+    assert response.headers["content-type"] == "application/json"
+
+    # POST detail should return raw YAML content.
+    response = client.post("/documents/2")
+    assert response.status_code == 200
+    assert response.text == (tmp_path / "2.yaml").read_text()
+    assert response.headers["content-type"] == "application/x-yaml"
+
 
 def test_export_md_endpoint(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary
- add POST /documents to return raw document summaries
- add POST /documents/{ver_id} to return raw file contents
- test raw document endpoints

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ca0d06888327bddf0aa0c113ad79