### PR TITLE
Improve web page controls

### DIFF
--- a/leropa/web/templates/index.html
+++ b/leropa/web/templates/index.html
@@ -5,26 +5,18 @@
 
 <div class="mb-4">
   <h2>Ask a question</h2>
-  <form id="ask-form" class="row g-3">
-    <div class="col-auto flex-grow-1">
-      <input id="question" name="question" class="form-control" placeholder="Your question" />
-    </div>
-    <div class="col-auto">
-      <button class="btn btn-primary" type="submit">Ask</button>
-    </div>
+  <form id="ask-form" class="input-group">
+    <input type="text" id="question" name="question" class="form-control" placeholder="Your question" aria-label="Question" />
+    <button class="btn btn-primary" type="submit">Ask</button>
   </form>
-  <pre id="answer" class="mt-3 bg-light p-3"></pre>
+  <textarea id="answer" class="form-control mt-3" rows="4" readonly></textarea>
 </div>
 
 <div class="mb-4">
   <h2>Search documents</h2>
-  <form id="search-form" class="row g-3">
-    <div class="col-auto flex-grow-1">
-      <input id="query" name="query" class="form-control" placeholder="Search query" />
-    </div>
-    <div class="col-auto">
-      <button class="btn btn-secondary" type="submit">Search</button>
-    </div>
+  <form id="search-form" class="input-group">
+    <input type="text" id="query" name="query" class="form-control" placeholder="Search query" aria-label="Search query" />
+    <button class="btn btn-secondary" type="submit">Search</button>
   </form>
   <ul id="hits" class="list-group mt-3"></ul>
 </div>
@@ -57,7 +49,10 @@ askForm.addEventListener('submit', async (e) => {
     // Parse the JSON answer and display it to the user.
 
     const data = await resp.json();
-    document.getElementById('answer').textContent = data.text || '';
+
+    // Populate the textarea with the answer text.
+
+    document.getElementById('answer').value = data.text || '';
   } catch (err) {
     // Show a toast notification for any errors.
 


### PR DESCRIPTION
## Summary
- Use Bootstrap input groups to streamline question and search forms
- Show answers in a readonly textarea styled as a form control
- Update client-side script to fill the textarea with responses

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d36588f08327b9b493f62ea71783