### PR TITLE
Show citations and article links in QA results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - List available LLM models and allow selecting the model via CLI and web API.
 - Expose endpoints to list and view structured documents via FastAPI.
 - Add `web` command to start FastAPI with Uvicorn.
+- Show citation links on the question-answer web page.

--- a/leropa/web/templates/index.html
+++ b/leropa/web/templates/index.html
@@ -10,6 +10,7 @@
     <button class="btn btn-primary" type="submit">Ask</button>
   </form>
   <textarea id="answer" class="form-control mt-3" rows="4" readonly></textarea>
+  <ul id="citations" class="list-group mt-3"></ul>
 </div>
 
 <div class="mb-4">
@@ -53,6 +54,26 @@ askForm.addEventListener('submit', async (e) => {
     // Populate the textarea with the answer text.
 
     document.getElementById('answer').value = data.text || '';
+
+    // Clear existing citation list before adding new items.
+
+    const citationList = document.getElementById('citations');
+    citationList.innerHTML = '';
+
+    // Add each context as a citation linking to the document details page.
+
+    (data.contexts || []).forEach((ctx, idx) => {
+      const src = ctx.source_file || '';
+      const verId = src.split('/').pop().split('.')[0];
+      const url = `/documents/${verId}?format=html#${ctx.article_id}`;
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      const a = document.createElement('a');
+      a.href = url;
+      a.textContent = `[${idx + 1}] Art. ${ctx.label}`;
+      li.appendChild(a);
+      citationList.appendChild(li);
+    });
   } catch (err) {
     // Show a toast notification for any errors.
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -96,6 +96,15 @@ def test_root_page_links_documents() -> None:
     assert '<a href="/documents?format=html"' in response.text
 
 
+def test_root_page_has_citations_list() -> None:
+    """Index page should include a container for citations."""
+
+    client = _client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'id="citations"' in response.text
+
+
 def test_chat_endpoint_uses_selected_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -368,13 +377,12 @@ def test_rag_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
         client.post("/rag/search", json={"query": "q"}).json()[0]["text"]
         == "hit"
     )
-    assert (
-        client.get("/rag/ask", params={"question": "q"}).json()["text"]
-        == "ans"
-    )
-    assert (
-        client.post("/rag/ask", json={"question": "q"}).json()["text"] == "ans"
-    )
+    resp = client.get("/rag/ask", params={"question": "q"}).json()
+    assert resp["text"] == "ans"
+    assert resp["contexts"] == []
+    resp = client.post("/rag/ask", json={"question": "q"}).json()
+    assert resp["text"] == "ans"
+    assert resp["contexts"] == []
     assert (
         client.delete("/rag/delete", params={"article_id": "a"}).json()[
             "deleted"


### PR DESCRIPTION
## Summary
- Display citation list with links to document articles on the question-answer page
- Document this new feature in the changelog
- Cover citation list and RAG context in web tests

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f698cab083278c88957e489678c7