### PR TITLE
Add separate document admin page and reuse document cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,5 @@
 - Add `web` command to start FastAPI with Uvicorn.
 - Show citation links on the question-answer web page.
 - Cache document metadata for 15 minutes and return it with RAG answers.
+- Reuse document metadata cache for document listings.
+- Provide separate admin page for adding and deleting documents.

--- a/leropa/web/templates/documents.html
+++ b/leropa/web/templates/documents.html
@@ -2,97 +2,11 @@
 {% block content %}
 <h1>Documents</h1>
 
-<div class="mb-3">
-  <form id="add-form" class="input-group">
-    <input type="text" class="form-control" name="ver_id" placeholder="Document ID" required />
-    <button class="btn btn-primary" type="submit">Add</button>
-  </form>
-</div>
-
-<form id="delete-form">
-  <ul class="list-group">
-    {% for doc in documents %}
-      <li class="list-group-item d-flex align-items-center">
-        <input class="form-check-input me-2" type="checkbox" value="{{ doc.ver_id }}" name="ver_id" />
-        <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
-      </li>
-    {% endfor %}
-  </ul>
-  <button id="delete-button" type="button" class="btn btn-danger mt-3">Remove Selected</button>
-  <button id="recreate-button" type="button" class="btn btn-warning mt-3 ms-2">Recreate Collection</button>
-</form>
-
-<div id="progress" class="d-none text-center mt-3">
-  <div class="spinner-border" role="status"></div>
-  <span class="ms-2">Processing...</span>
-</div>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const progress = document.getElementById('progress');
-
-  function showProgress(show) {
-    progress.classList.toggle('d-none', !show);
-  }
-
-  document.getElementById('add-form').addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const form = e.target;
-    const verId = form.ver_id.value.trim();
-    if (!verId) return;
-    showProgress(true);
-    try {
-      const resp = await fetch('/documents/add', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ver_id: verId})
-      });
-      if (!resp.ok) {
-        throw new Error(await resp.text() || resp.statusText);
-      }
-      location.reload();
-    } catch (err) {
-      showToast(err.message);
-    } finally {
-      showProgress(false);
-    }
-  });
-
-  document.getElementById('delete-button').addEventListener('click', async () => {
-    const ids = Array.from(document.querySelectorAll('input[name="ver_id"]:checked')).map(el => el.value);
-    if (!ids.length) return;
-    showProgress(true);
-    try {
-      const resp = await fetch('/documents/delete', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ids})
-      });
-      if (!resp.ok) {
-        throw new Error(await resp.text() || resp.statusText);
-      }
-      location.reload();
-    } catch (err) {
-      showToast(err.message);
-    } finally {
-      showProgress(false);
-    }
-  });
-
-  document.getElementById('recreate-button').addEventListener('click', async () => {
-    showProgress(true);
-    try {
-      const resp = await fetch('/rag/recreate');
-      if (!resp.ok) {
-        throw new Error(await resp.text() || resp.statusText);
-      }
-      showToast('Collection recreated');
-    } catch (err) {
-      showToast(err.message);
-    } finally {
-      showProgress(false);
-    }
-  });
-});
-</script>
+<ul class="list-group">
+  {% for doc in documents %}
+    <li class="list-group-item">
+      <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/leropa/web/templates/documents_admin.html
+++ b/leropa/web/templates/documents_admin.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Documents</h1>
+
+<div class="mb-3">
+  <form id="add-form" class="input-group">
+    <input type="text" class="form-control" name="ver_id" placeholder="Document ID" required />
+    <button class="btn btn-primary" type="submit">Add</button>
+  </form>
+</div>
+
+<form id="delete-form">
+  <ul class="list-group">
+    {% for doc in documents %}
+      <li class="list-group-item d-flex align-items-center">
+        <input class="form-check-input me-2" type="checkbox" value="{{ doc.ver_id }}" name="ver_id" />
+        <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+  <button id="delete-button" type="button" class="btn btn-danger mt-3">Remove Selected</button>
+  <button id="recreate-button" type="button" class="btn btn-warning mt-3 ms-2">Recreate Collection</button>
+</form>
+
+<div id="progress" class="d-none text-center mt-3">
+  <div class="spinner-border" role="status"></div>
+  <span class="ms-2">Processing...</span>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const progress = document.getElementById('progress');
+
+  function showProgress(show) {
+    progress.classList.toggle('d-none', !show);
+  }
+
+  document.getElementById('add-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const verId = form.ver_id.value.trim();
+    if (!verId) return;
+    showProgress(true);
+    try {
+      const resp = await fetch('/documents/add', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ver_id: verId})
+      });
+      if (!resp.ok) {
+        throw new Error(await resp.text() || resp.statusText);
+      }
+      location.reload();
+    } catch (err) {
+      showToast(err.message);
+    } finally {
+      showProgress(false);
+    }
+  });
+
+  document.getElementById('delete-button').addEventListener('click', async () => {
+    const ids = Array.from(document.querySelectorAll('input[name="ver_id"]:checked')).map(el => el.value);
+    if (!ids.length) return;
+    showProgress(true);
+    try {
+      const resp = await fetch('/documents/delete', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ids})
+      });
+      if (!resp.ok) {
+        throw new Error(await resp.text() || resp.statusText);
+      }
+      location.reload();
+    } catch (err) {
+      showToast(err.message);
+    } finally {
+      showProgress(false);
+    }
+  });
+
+  document.getElementById('recreate-button').addEventListener('click', async () => {
+    showProgress(true);
+    try {
+      const resp = await fetch('/rag/recreate');
+      if (!resp.ok) {
+        throw new Error(await resp.text() || resp.statusText);
+      }
+      showToast('Collection recreated');
+    } catch (err) {
+      showToast(err.message);
+    } finally {
+      showProgress(false);
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -203,6 +203,7 @@ def test_document_endpoints(
     assert response.status_code == 200
     assert "Doc1" in response.text
     assert "Doc2" in response.text
+    assert 'id="add-form"' not in response.text
 
     # Fetching a document should strip ``full_text``.
     response = client.get("/documents/1")
@@ -215,6 +216,82 @@ def test_document_endpoints(
     response = client.get("/documents/1", params={"format": "html"})
     assert response.status_code == 200
     assert "Doc1" in response.text
+
+
+def test_documents_admin_page_shows_forms(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Admin page should expose controls for managing documents."""
+
+    doc = {
+        "document": {
+            "source": "s",
+            "ver_id": "1",
+            "title": "Doc1",
+            "description": "",
+            "keywords": "",
+            "history": [],
+            "prev_ver": None,
+            "next_ver": None,
+        },
+        "articles": [],
+        "books": [],
+        "annexes": [],
+    }
+
+    (tmp_path / "1.json").write_text(json_dumps(doc))
+    monkeypatch.setenv("LEROPA_DOCUMENTS", str(tmp_path))
+
+    client = _client()
+    response = client.get("/documents-admin")
+    assert response.status_code == 200
+    assert 'id="add-form"' in response.text
+    assert 'id="delete-button"' in response.text
+
+
+def test_documents_listing_uses_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Listing documents should use the metadata cache."""
+
+    doc = {
+        "document": {
+            "source": "s",
+            "ver_id": "1",
+            "title": "Doc1",
+            "description": "",
+            "keywords": "",
+            "history": [],
+            "prev_ver": None,
+            "next_ver": None,
+        },
+        "articles": [],
+        "books": [],
+        "annexes": [],
+    }
+
+    (tmp_path / "1.yaml").write_text(
+        yaml.safe_dump(doc, allow_unicode=True, sort_keys=False)
+    )
+    monkeypatch.setenv("LEROPA_DOCUMENTS", str(tmp_path))
+
+    calls = {"n": 0}
+
+    from leropa.parser.document_info import DocumentInfo
+
+    def fake_load(path: Path) -> DocumentInfo:
+        calls["n"] += 1
+        data = yaml.safe_load(path.read_text())
+        return DocumentInfo(**data["document"])
+
+    monkeypatch.setattr(
+        "leropa.web.routes.documents.load_document_info", fake_load
+    )
+
+    client = _client()
+    response = client.get("/documents")
+    assert response.status_code == 200
+    assert calls["n"] == 1
 
 
 def test_document_admin_add_delete(


### PR DESCRIPTION
## Summary
- reuse DocumentInfo cache when listing stored documents
- add dedicated admin page for adding and deleting documents
- cover admin UI and cache usage with new tests

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b31e91686c832796c48e60157cccc4