### PR TITLE
Add translation support and lang parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,5 @@
 - Cache document metadata for 15 minutes and return it with RAG answers.
 - Reuse document metadata cache for document listings.
 - Provide separate admin page for adding and deleting documents.
+- Add simple translation support for web pages with ``lang`` parameter and ``tr`` helper.
+- Convert ``rag_legal_qdrant`` language setting into a function parameter.

--- a/leropa/llm/rag_legal_qdrant.py
+++ b/leropa/llm/rag_legal_qdrant.py
@@ -130,8 +130,6 @@ RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "BAAI/bge-reranker-base")
 TOP_K_RETRIEVE = int(os.environ.get("TOP_K_RETRIEVE", "64"))
 TOP_K_CONTEXT = int(os.environ.get("TOP_K_CONTEXT", "16"))
 
-LANGUAGE: Literal["ro", "en"] = os.environ.get("DLG_LNG", "ro")  # type: ignore
-assert LANGUAGE in ["ro", "en"]
 
 # Tokenizer for chunking
 try:
@@ -562,6 +560,7 @@ def ask_with_context(
     top_k: int = TOP_K_RETRIEVE,
     final_k: int = TOP_K_CONTEXT,
     use_reranker: bool = True,
+    language: Literal["en", "ro"] = "ro",
 ) -> Dict[str, Any]:
     """Retrieve → (optional rerank) → generate answer with citations.
 
@@ -601,7 +600,7 @@ def ask_with_context(
         ctx_blocks.append(f"[{i}] Source: {src}\n{c['text']}")
     context = "\n\n".join(ctx_blocks)
 
-    if LANGUAGE == "en":
+    if language == "en":
         system = (
             "You are a precise legal research assistant. "
             "Use ONLY the supplied CONTEXT to answer the user's question. "
@@ -613,7 +612,7 @@ def ask_with_context(
             f"QUESTION:\n{question}\n\nCONTEXT:\n{context}\n\n"
             "Answer with citations like [1], [2]."
         )
-    elif LANGUAGE == "ro":
+    elif language == "ro":
         system = (
             "Esti un asistent legal exact care utilizează doar CONTEXTUL "
             "furnizat pentru a răspunde la întrebarea utilizatorului. "
@@ -626,7 +625,7 @@ def ask_with_context(
             "Răspunde cu citările ca [1], [2]."
         )
     else:
-        raise ValueError(f"Invalid language: {LANGUAGE}")
+        raise ValueError(f"Invalid language: {language}")
 
     answer_text = _ollama_chat(system, user, stream=False)
 

--- a/leropa/web/routes/chat.py
+++ b/leropa/web/routes/chat.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Form  # type: ignore[import-not-found]
 from fastapi.responses import HTMLResponse  # type: ignore[import-not-found]
 
 from leropa.cli import _import_llm_module
 from leropa.llm import available_models
+
+from ..utils import get_translator
 
 router = APIRouter()
 
@@ -20,12 +22,15 @@ _RAG: Any = _import_llm_module("rag_legal_qdrant")
 async def chat(
     question: str = Form(...),
     model: str = Form("llama3.2:3b"),
+    lang: Literal["en", "ro"] = "en",
 ) -> HTMLResponse:
     """Handle chat questions and display the answer."""
 
     # Configure the generation model on the RAG helper and generate an answer.
     setattr(_RAG, "GEN_MODEL", model)
-    answer = _RAG.ask_with_context(question, collection="legal_articles")
+    answer = _RAG.ask_with_context(
+        question, collection="legal_articles", language=lang
+    )
 
     # Build the model options for rendering the form again, marking selection.
     model_opts = "".join(
@@ -34,12 +39,13 @@ async def chat(
         for name in available_models()
     )
 
+    tr = get_translator(lang)
     # Render the answer in a new HTML page along with the form.
     return HTMLResponse(
         f"<p>{answer['text']}</p>"
-        "<form method='post' action='/chat'>"
+        f"<form method='post' action='/chat?lang={lang}'>"
         f"<select name='model'>{model_opts}</select>"
         "<input name='question' type='text'/>"
-        "<button type='submit'>Ask</button>"
+        f"<button type='submit'>{tr('ask_button', 'Ask')}</button>"
         "</form>"
     )

--- a/leropa/web/routes/document_detail.py
+++ b/leropa/web/routes/document_detail.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import (  # type: ignore[import-not-found]
     APIRouter,
     HTTPException,
@@ -14,6 +16,7 @@ from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 from ..utils import (
     create_jinja_context,
     document_files,
+    get_translator,
     load_document_file,
     strip_full_text,
     templates,
@@ -27,6 +30,7 @@ async def get_document(
     ver_id: str,
     request: Request,
     format: str = Query(default="json", enum=["json", "html"]),
+    lang: Literal["en", "ro"] = "en",
 ) -> Response:
     """Return a specific document by version identifier.
 
@@ -42,7 +46,11 @@ async def get_document(
     # Locate the document file matching ``ver_id``.
     file_path = next((p for p in document_files() if p.stem == ver_id), None)
     if file_path is None:
-        raise HTTPException(status_code=404, detail="Document not found")
+        tr = get_translator(lang)
+        raise HTTPException(
+            status_code=404,
+            detail=tr("document_not_found", "Document not found"),
+        )
 
     doc = strip_full_text(load_document_file(file_path))
 
@@ -56,6 +64,7 @@ async def get_document(
                 doc=doc,
                 doc_articles={a["article_id"]: a for a in doc["articles"]},
                 title=f"{title} | leropa",
+                lang=lang,
             ),
         )
 
@@ -63,7 +72,9 @@ async def get_document(
 
 
 @router.post("/documents/{ver_id}")
-async def get_document_raw(ver_id: str) -> Response:
+async def get_document_raw(
+    ver_id: str, lang: Literal["en", "ro"] = "en"
+) -> Response:
     """Return the raw content of a document file.
 
     Args:
@@ -76,7 +87,11 @@ async def get_document_raw(ver_id: str) -> Response:
     # Locate the document file matching ``ver_id``.
     file_path = next((p for p in document_files() if p.stem == ver_id), None)
     if file_path is None:
-        raise HTTPException(status_code=404, detail="Document not found")
+        tr = get_translator(lang)
+        raise HTTPException(
+            status_code=404,
+            detail=tr("document_not_found", "Document not found"),
+        )
 
     # Read the file contents as text.
     text = file_path.read_text(encoding="utf-8")

--- a/leropa/web/routes/documents.py
+++ b/leropa/web/routes/documents.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Literal
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import (  # type: ignore[import-not-found]
@@ -26,6 +27,7 @@ from ..utils import (
     create_jinja_context,
     document_files,
     get_documents_dir,
+    get_translator,
     load_document_file,
     templates,
 )
@@ -61,6 +63,7 @@ def _load_summaries() -> DocumentSummaryList:
 async def list_documents(
     request: Request,
     format: str = Query(default="json", enum=["json", "html"]),
+    lang: Literal["en", "ro"] = "en",
 ) -> Response:
     """List structured documents available on the server.
 
@@ -77,12 +80,14 @@ async def list_documents(
 
     # Render as HTML when requested.
     if format == "html":
+        tr = get_translator(lang)
         return templates.TemplateResponse(
             "documents.html",
             context=create_jinja_context(
                 request=request,
                 documents=summaries,
-                title="Documents | leropa",
+                title=f"{tr('documents_title', 'Documents')} | leropa",
+                lang=lang,
             ),
         )
 
@@ -102,7 +107,9 @@ async def list_documents_raw() -> JSONResponse:
 
 
 @router.get("/documents-admin")
-async def documents_admin(request: Request) -> Response:
+async def documents_admin(
+    request: Request, lang: Literal["en", "ro"] = "en"
+) -> Response:
     """Render admin page for adding and deleting documents.
 
     Args:
@@ -113,12 +120,14 @@ async def documents_admin(request: Request) -> Response:
     """
 
     summaries = _load_summaries()
+    tr = get_translator(lang)
     return templates.TemplateResponse(
         "documents_admin.html",
         context=create_jinja_context(
             request=request,
             documents=summaries,
-            title="Documents Admin | leropa",
+            title=f"{tr('administration_title', 'Administration')} | leropa",
+            lang=lang,
         ),
     )
 

--- a/leropa/web/routes/rag_ask.py
+++ b/leropa/web/routes/rag_ask.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter  # type: ignore[import-not-found]
 from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 from pydantic import BaseModel  # type: ignore[import-not-found]
@@ -29,6 +31,7 @@ class AskRequest(BaseModel):
     finalk: int = 8
     no_rerank: bool = False
     model: str | None = None
+    lang: Literal["en", "ro"] = "en"
 
 
 # Load the RAG module once; used for answering questions.
@@ -43,6 +46,7 @@ async def rag_ask_get(
     finalk: int = 8,
     no_rerank: bool = False,
     model: str | None = None,
+    lang: Literal["en", "ro"] = "en",
 ) -> JSONResponse:
     """Ask a question via query parameters and receive an answer.
 
@@ -67,6 +71,7 @@ async def rag_ask_get(
         top_k=topk,
         final_k=finalk,
         use_reranker=not no_rerank,
+        language=lang,
     )
     return JSONResponse(answer)
 
@@ -91,5 +96,6 @@ async def rag_ask_post(payload: AskRequest) -> JSONResponse:
         top_k=payload.topk,
         final_k=payload.finalk,
         use_reranker=not payload.no_rerank,
+        language=payload.lang,
     )
     return JSONResponse(answer)

--- a/leropa/web/routes/root.py
+++ b/leropa/web/routes/root.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Request  # type: ignore[import-not-found]
 from fastapi.responses import HTMLResponse  # type: ignore[import-not-found]
 
@@ -11,7 +13,9 @@ router = APIRouter()
 
 
 @router.get("/")
-async def root_page(request: Request) -> HTMLResponse:
+async def root_page(
+    request: Request, lang: Literal["en", "ro"] = "en"
+) -> HTMLResponse:
     """Render the main page with chat and search forms.
 
     Args:
@@ -23,5 +27,5 @@ async def root_page(request: Request) -> HTMLResponse:
 
     # Render the Jinja2 template for the main page.
     return templates.TemplateResponse(
-        "index.html", context=create_jinja_context(request=request)
+        "index.html", context=create_jinja_context(request=request, lang=lang)
     )

--- a/leropa/web/templates/base.html
+++ b/leropa/web/templates/base.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
 <head>
   <meta charset="utf-8" />
-  <title>{{ title or "LeRoPa" }}</title>
+  <title>{{ title or tr('site_title', 'LeRoPa') }}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
   {% block head %}{% endblock %}
 </head>

--- a/leropa/web/templates/document_detail.html
+++ b/leropa/web/templates/document_detail.html
@@ -27,7 +27,7 @@
 {%- block content %}
 <h1 class="doc-title">{{ doc.document.title }}</h1>
 <p>
-  Sursa:
+  {{ tr('source', 'Source:') }}
   <a href="{{ doc.document.source }}">
     <span class="doc-source-link">
       <i class="bi bi-link"></i>

--- a/leropa/web/templates/documents.html
+++ b/leropa/web/templates/documents.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Documents</h1>
+<h1>{{ tr('documents_title', 'Documents') }}</h1>
 
 <ul class="list-group">
   {% for doc in documents %}
     <li class="list-group-item">
-      <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
+      <a href="/documents/{{ doc.ver_id }}?format=html&lang={{ lang }}">{{ doc.title }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/leropa/web/templates/documents_admin.html
+++ b/leropa/web/templates/documents_admin.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Administration</h1>
+<h1>{{ tr('administration_title', 'Administration') }}</h1>
 
 <div class="mb-3">
   <form id="add-form" class="input-group">
-    <input type="text" class="form-control" name="ver_id" placeholder="Document ID" required />
-    <button class="btn btn-primary" type="submit">Add</button>
+    <input type="text" class="form-control" name="ver_id" placeholder="{{ tr('document_id_placeholder', 'Document ID') }}" required />
+    <button class="btn btn-primary" type="submit">{{ tr('add_button', 'Add') }}</button>
   </form>
 </div>
 
@@ -14,17 +14,17 @@
     {% for doc in documents %}
       <li class="list-group-item d-flex align-items-center">
         <input class="form-check-input me-2" type="checkbox" value="{{ doc.ver_id }}" name="ver_id" />
-        <a href="/documents/{{ doc.ver_id }}?format=html">{{ doc.title }}</a>
+        <a href="/documents/{{ doc.ver_id }}?format=html&lang={{ lang }}">{{ doc.title }}</a>
       </li>
     {% endfor %}
   </ul>
-  <button id="delete-button" type="button" class="btn btn-danger mt-3">Remove Selected</button>
-  <button id="recreate-button" type="button" class="btn btn-warning mt-3 ms-2">Recreate Collection</button>
+  <button id="delete-button" type="button" class="btn btn-danger mt-3">{{ tr('remove_selected', 'Remove Selected') }}</button>
+  <button id="recreate-button" type="button" class="btn btn-warning mt-3 ms-2">{{ tr('recreate_collection', 'Recreate Collection') }}</button>
 </form>
 
 <div id="progress" class="d-none text-center mt-3">
   <div class="spinner-border" role="status"></div>
-  <span class="ms-2">Processing...</span>
+  <span class="ms-2">{{ tr('processing', 'Processing...') }}</span>
 </div>
 
 <script>
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!resp.ok) {
         throw new Error(await resp.text() || resp.statusText);
       }
-      showToast('Collection recreated');
+      showToast('{{ tr('collection_recreated', 'Collection recreated') }}');
     } catch (err) {
       showToast(err.message);
     } finally {

--- a/leropa/web/templates/index.html
+++ b/leropa/web/templates/index.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>LeRoPa RAG Demo</h1>
-<p><a href="/documents?format=html">Documents</a></p>
+<h1>{{ tr('rag_demo_title', 'LeRoPa RAG Demo') }}</h1>
+<p><a href="/documents?format=html&lang={{ lang }}">{{ tr('documents_link', 'Documents') }}</a></p>
 
 <div class="mb-4">
-  <h2>Ask a question</h2>
+  <h2>{{ tr('ask_question_title', 'Ask a question') }}</h2>
   <form id="ask-form" class="input-group">
     <select id="model" name="model" class="form-select"></select>
-    <input type="text" id="question" name="question" class="form-control" placeholder="Your question" aria-label="Question" />
-    <button class="btn btn-primary" type="submit">Ask</button>
+    <input type="text" id="question" name="question" class="form-control" placeholder="{{ tr('your_question', 'Your question') }}" aria-label="{{ tr('question_aria', 'Question') }}" />
+    <button class="btn btn-primary" type="submit">{{ tr('ask_button', 'Ask') }}</button>
   </form>
   <!-- textarea id="answer" class="form-control mt-3" rows="4" readonly></textarea -->
   <div id="answer" class="form-control mt-3" ></div>
@@ -16,10 +16,10 @@
 </div>
 
 <div class="mb-4">
-  <h2>Search documents</h2>
+  <h2>{{ tr('search_documents_title', 'Search documents') }}</h2>
   <form id="search-form" class="input-group">
-    <input type="text" id="query" name="query" class="form-control" placeholder="Search query" aria-label="Search query" />
-    <button class="btn btn-secondary" type="submit">Search</button>
+    <input type="text" id="query" name="query" class="form-control" placeholder="{{ tr('search_query', 'Search query') }}" aria-label="{{ tr('search_query', 'Search query') }}" />
+    <button class="btn btn-secondary" type="submit">{{ tr('search_button', 'Search') }}</button>
   </form>
   <ul id="hits" class="list-group mt-3"></ul>
 </div>
@@ -28,7 +28,7 @@
   <div class="progress">
     <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
   </div>
-  <div class="text-muted mt-1">Waiting for reply...</div>
+  <div class="text-muted mt-1">{{ tr('waiting_reply', 'Waiting for reply...') }}</div>
   
 </div>
 
@@ -69,7 +69,7 @@ askForm.addEventListener('submit', async (e) => {
   const question = document.getElementById('question').value;
   const model = document.getElementById('model').value;
   if (question.trim() === '') {
-    showToast('Please enter a question');
+    showToast('{{ tr('please_enter_question', 'Please enter a question') }}');
     return;
   }
 
@@ -77,7 +77,7 @@ askForm.addEventListener('submit', async (e) => {
     showProgress(true);
 
     // Perform a POST request to the ask endpoint.
-    const resp = await fetch('/rag/ask', {
+    const resp = await fetch('/rag/ask?lang={{ lang }}', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({question, model}),
@@ -103,7 +103,7 @@ askForm.addEventListener('submit', async (e) => {
       const src = ctx.source_file || '';
       const verId = ctx.file_id;
       const src_doc = data.documents[verId];
-      const url = `/documents/${verId}?format=html#${ctx.article_id}`;
+      const url = `/documents/${verId}?format=html&lang={{ lang }}#${ctx.article_id}`;
       const li = document.createElement('li');
       li.className = 'list-group-item';
       const a = document.createElement('a');
@@ -124,7 +124,7 @@ askForm.addEventListener('submit', async (e) => {
         return match;
       }
       const src_doc = data.documents[ctx.file_id];
-      const url = `/documents/${ctx.file_id}?format=html#${ctx.article_id}`;
+      const url = `/documents/${ctx.file_id}?format=html&lang={{ lang }}#${ctx.article_id}`;
       const title = `${src_doc.title || ''} - Art. ${ctx.label}`;
       return `<a href="${url}" title="${title}" target="_blank">${match}</a>`;
     });

--- a/leropa/web/utils.py
+++ b/leropa/web/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Literal
 
 import yaml  # type: ignore[import-untyped]
 from fastapi.templating import Jinja2Templates  # type: ignore
@@ -25,6 +25,48 @@ TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
 # Jinja2 template renderer shared by route handlers.
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+
+# Simple translation catalog for UI strings.
+TRANSLATIONS: dict[str, dict[str, str]] = {
+    "ro": {
+        "rag_demo_title": "Demo RAG LeRoPa",
+        "documents_link": "Documente",
+        "ask_question_title": "Pune o întrebare",
+        "your_question": "Întrebarea ta",
+        "question_aria": "Întrebare",
+        "ask_button": "Întreabă",
+        "search_documents_title": "Caută documente",
+        "search_query": "Căutare",
+        "search_button": "Caută",
+        "waiting_reply": "Se așteaptă răspuns...",
+        "please_enter_question": "Te rog introdu o întrebare",
+        "documents_title": "Documente",
+        "administration_title": "Administrare",
+        "document_id_placeholder": "ID document",
+        "add_button": "Adaugă",
+        "remove_selected": "Șterge selectate",
+        "recreate_collection": "Recreează colecția",
+        "processing": "Se procesează...",
+        "collection_recreated": "Colecția a fost recreată",
+        "source": "Sursa:",
+        "document_not_found": "Document inexistent",
+        "site_title": "LeRoPa",
+    }
+}
+
+
+def get_translator(lang: str) -> Callable[[str, str], str]:
+    """Return a translation function for ``lang``."""
+
+    catalog = TRANSLATIONS.get(lang, {})
+
+    def tr(code: str, default: str) -> str:
+        """Translate ``code`` falling back to ``default``."""
+
+        return catalog.get(code, default)
+
+    return tr
 
 
 def get_documents_dir() -> Path:
@@ -94,10 +136,13 @@ def strip_full_text(doc: JSONDict) -> JSONDict:
     return doc
 
 
-def create_jinja_context(**kwargs: object) -> dict[str, object]:
+def create_jinja_context(
+    lang: Literal["en", "ro"] = "en", **kwargs: object
+) -> dict[str, object]:
     """Create additional variables for the Jinja2 template renderer.
 
     Args:
+        lang: Language code used for translations.
         kwargs: Extra key-value pairs to inject into the template context.
 
     Returns:
@@ -105,5 +150,7 @@ def create_jinja_context(**kwargs: object) -> dict[str, object]:
     """
     return {
         "is_str": lambda x: isinstance(x, str),
+        "tr": get_translator(lang),
+        "lang": lang,
         **kwargs,
     }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -57,6 +57,7 @@ def test_chat_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
             top_k: int = 24,
             final_k: int = 8,
             use_reranker: bool = True,
+            language: str = "en",
         ) -> JSONDict:
             return {
                 "text": f"Echo: {question}",
@@ -97,7 +98,7 @@ def test_root_page_links_documents() -> None:
     client = _client()
     response = client.get("/")
     assert response.status_code == 200
-    assert '<a href="/documents?format=html"' in response.text
+    assert '<a href="/documents?format=html&lang=en"' in response.text
 
 
 def test_root_page_has_citations_list() -> None:
@@ -460,6 +461,7 @@ def test_rag_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
             top_k: int,
             final_k: int,
             use_reranker: bool,
+            language: str = "en",
         ) -> dict[str, object]:
             return {"text": "ans", "contexts": [], "documents": {}}
 

--- a/tests/test_web_utils.py
+++ b/tests/test_web_utils.py
@@ -1,0 +1,18 @@
+from typing import Callable, cast
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from leropa.web.utils import create_jinja_context
+
+
+def test_translation_function() -> None:
+    ctx_en = create_jinja_context()
+    tr_en = cast(Callable[[str, str], str], ctx_en["tr"])
+    assert tr_en("ask_button", "Ask") == "Ask"
+
+    ctx_ro = create_jinja_context(lang="ro")
+    tr_ro = cast(Callable[[str, str], str], ctx_ro["tr"])
+    assert tr_ro("ask_button", "Ask") == "Întreabă"
+    assert tr_ro("missing", "Fallback") == "Fallback"


### PR DESCRIPTION
## Summary
- add simple translation catalog and context helper
- allow web routes and RAG helper to choose language
- translate templates and admin UI

## Testing
- `make format`
- `make delint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f9c174d8832783e4522bb48a7452